### PR TITLE
Ready: Fixed issue #17

### DIFF
--- a/macro/Unpack_GETDecoder2/runfiles/NSCL/alphas/create_runfile.sh
+++ b/macro/Unpack_GETDecoder2/runfiles/NSCL/alphas/create_runfile.sh
@@ -2,21 +2,30 @@
 
 if [ -z "$1" ];
 then
-  echo "==  Please provide the name of the run file "
-  echo "==   i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128/"
+  echo "== Please provide the output filename"
+  echo "==  i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128"
 
   return;
 fi
 
-RUN=$1
+if [ -z "$2" ];
+then
+  echo "== Please provide a directory to read files from"
+  echo "==  i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128"
+
+  return;
+fi
 
 OUTPUT=$1\.txt
-BUFF=buffer.txt
-> $PWD/$OUTPUT
 
-readlink -f $2/*.* >> $BUFF
-sed '/lookup/d' $BUFF >> $OUTPUT
-rm -rf $BUFF
-#sort -t "o" -k1n,1 $OUTPUT
-#sort -t"." -k2n,2  $OUTPUT
-#sort -n $OUTPUT >> $OUTPUT
+# get all files and folders ending on *.graw in the target directory (one per line)
+ls --color=never -1 $2/*.graw |
+# get the number following "CoBo" and (eventually) the number immediately before ".graw"
+# and write them like this: (\t beeing the tab-character)
+# {CoBoNumber}\t{Before.grawNumber}\t{original line}
+  perl -pe "s|(.*CoBo([0-9]+).*?(?:\.([0-9]*))?\.graw)|\2\t\3\t\1|" |
+# sort numerically by the first 2 columns
+  sort -n -k1,1 -k2,2 |
+# drop everything - except the third column
+# and write result into output file
+  cut -f3 > $OUTPUT

--- a/macro/Unpack_GETDecoder2/runfiles/create_runfile.sh
+++ b/macro/Unpack_GETDecoder2/runfiles/create_runfile.sh
@@ -2,21 +2,30 @@
 
 if [ -z "$1" ];
 then
-  echo "==  Please provide the name of the run file "
-  echo "==   i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128/"
+  echo "== Please provide the output filename"
+  echo "==  i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128"
 
   return;
 fi
 
-RUN=$1
+if [ -z "$2" ];
+then
+  echo "== Please provide a directory to read files from"
+  echo "==  i.e: ./create_runfile.sh ar46_run_0128 /data/ar46/run_0128"
+
+  return;
+fi
 
 OUTPUT=$1\.txt
-BUFF=buffer.txt
-> $PWD/$OUTPUT
 
-readlink -f $2/*.* >> $BUFF
-sed '/lookup/d' $BUFF >> $OUTPUT
-rm -rf $BUFF
-#sort -t "o" -k1n,1 $OUTPUT
-#sort -t"." -k2n,2  $OUTPUT
-#sort -n $OUTPUT >> $OUTPUT
+# get all files and folders ending on *.graw in the target directory (one per line)
+ls --color=never -1 $2/*.graw |
+# get the number following "CoBo" and (eventually) the number immediately before ".graw"
+# and write them like this: (\t beeing the tab-character)
+# {CoBoNumber}\t{Before.grawNumber}\t{original line}
+  perl -pe "s|(.*CoBo([0-9]+).*?(?:\.([0-9]*))?\.graw)|\2\t\3\t\1|" |
+# sort numerically by the first 2 columns
+  sort -n -k1,1 -k2,2 |
+# drop everything - except the third column
+# and write result into output file
+  cut -f3 > $OUTPUT


### PR DESCRIPTION
I rewrote the shell-scripts to fix the issues mentioned in #17.

First, the script will extract all the releant numbers:
```shell
0               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo0_run_0080_11Dec14_07h59m52s.graw
1               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo1_run_0080_11Dec14_07h59m52s.graw
2       125     /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.125.graw
2       13      /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.13.graw
3               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo3_run_0080_11Dec14_07h59m52s.graw
4               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo4_run_0080_11Dec14_07h59m52s.graw
6               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo6_run_0080_11Dec14_07h59m52s.graw
74      1       /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo74_run_0080_11Dec14_07h59m52s.1.graw
710             /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo710_run_0080_11Dec14_07h59m52s.graw
8               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo8_run_0080_11Dec14_07h59m52s.graw
9       1       /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.1.graw
9               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.graw
```

then it will sort

```shell
0               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo0_run_0080_11Dec14_07h59m52s.graw
1               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo1_run_0080_11Dec14_07h59m52s.graw
2       13      /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.13.graw
2       125     /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.125.graw
3               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo3_run_0080_11Dec14_07h59m52s.graw
4               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo4_run_0080_11Dec14_07h59m52s.graw
6               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo6_run_0080_11Dec14_07h59m52s.graw
8               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo8_run_0080_11Dec14_07h59m52s.graw
9               /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.graw
9       1       /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.1.graw
74      1       /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo74_run_0080_11Dec14_07h59m52s.1.graw
710             /mnt/analysis/attpcroot/data_alphas/run_0080/CoBo710_run_0080_11Dec14_07h59m52s.graw
```

and finally it will remove the numbers again

```shell
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo0_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo1_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.13.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo2_run_0080_11Dec14_07h59m52s.125.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo3_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo4_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo6_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo8_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo9_run_0080_11Dec14_07h59m52s.1.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo74_run_0080_11Dec14_07h59m52s.1.graw
/mnt/analysis/attpcroot/data_alphas/run_0080/CoBo710_run_0080_11Dec14_07h59m52s.graw
```

and that's basically it.
It also works correctly with a mixed number of digits.