### PR TITLE
Add missing include TFile.h

### DIFF
--- a/AtGenerators/ATTPCFissionGeneratorV2.cxx
+++ b/AtGenerators/ATTPCFissionGeneratorV2.cxx
@@ -1,5 +1,5 @@
 #include "ATTPCFissionGeneratorV2.h"
-
+#include "TFile.h"
 #include "FairPrimaryGenerator.h"
 #include "FairRootManager.h"
 #include "FairLogger.h"

--- a/AtGenerators/ATTPCFissionGeneratorV3.cxx
+++ b/AtGenerators/ATTPCFissionGeneratorV3.cxx
@@ -1,5 +1,5 @@
 #include "ATTPCFissionGeneratorV3.h"
-
+#include "TFile.h"
 // Default constructor
 ATTPCFissionGeneratorV3::ATTPCFissionGeneratorV3():
   nTracks(0)

--- a/s800/ATMergeTask.cc
+++ b/s800/ATMergeTask.cc
@@ -1,5 +1,5 @@
 #include "ATMergeTask.hh"
-
+#include "TFile.h"
 // FAIRROOT classes
 #include "FairRootManager.h"
 #include "FairRun.h"


### PR DESCRIPTION
TFile.h needed to be included in these files for using the version without PCL in Mac version 10.15.6 (19G2021)