### PR TITLE
Missing includes and maximum tracks in digitalization display set to 20

### DIFF
--- a/AtEventDisplay/AtEventDrawTask.cxx
+++ b/AtEventDisplay/AtEventDrawTask.cxx
@@ -518,10 +518,10 @@ void AtEventDrawTask::DrawHitPoints()
       } else if (fPatternEventArray) {
          AtPatternEvent *patternEvent = dynamic_cast<AtPatternEvent *>(fPatternEventArray->At(0));
          TrackCand = patternEvent->GetTrackCand();
-         for (Int_t i = 0; i < 10; i++)
+         for (Int_t i = 0; i < 20; i++)
             fHitSetTFHC[i] = 0;
 
-         if (TrackCand.size() < 10) {
+         if (TrackCand.size() < 20) {
             for (Int_t i = 0; i < TrackCand.size(); i++) {
 
                AtTrack track = TrackCand.at(i);
@@ -1110,7 +1110,7 @@ void AtEventDrawTask::Reset()
 
          if (fLineNum > 0) {
             for (Int_t i = 0; i < fLineNum; i++) {
-               if (fHitSetMC[i]) {
+               if (fHitSetTFHC[i]) {
                   gEve->RemoveElement(fHitSetTFHC[i], fEventManager);
                }
             }

--- a/AtEventDisplay/AtEventDrawTask.h
+++ b/AtEventDisplay/AtEventDrawTask.h
@@ -52,6 +52,7 @@ class TVector3;
 
 #include <Rtypes.h>
 #include <fstream>
+#include "TF1.h"
 
 #ifndef __CINT__ // Boost
 #include <boost/multi_array.hpp>
@@ -170,7 +171,7 @@ private:
    TEvePointSet *fHitSetMin;
 
    TEvePointSet *fHitSetMC[5];    // For MC results
-   TEvePointSet *fHitSetTFHC[10]; // for TrackFinderHC
+   TEvePointSet *fHitSetTFHC[20]; // for TrackFinderHC
 
    // TEveGeoShape* x;
    // std::vector<TEveGeoShape*> hitSphereArray;

--- a/AtEventDisplay/AtEventManager.h
+++ b/AtEventDisplay/AtEventManager.h
@@ -11,6 +11,7 @@
 #include "FairTask.h"
 
 #include "TCanvas.h"
+#include "TFile.h"
 
 #ifndef __CINT__ // Boost
 #include <boost/multi_array.hpp>

--- a/AtEventDisplay/AtEventManagerProto.h
+++ b/AtEventDisplay/AtEventManagerProto.h
@@ -11,6 +11,7 @@
 #include "FairTask.h"
 
 #include "TCanvas.h"
+#include "TFile.h"
 
 #ifndef __CINT__ // Boost
 #include <boost/multi_array.hpp>

--- a/AtEventDisplay/AtEventManagerS800.h
+++ b/AtEventDisplay/AtEventManagerS800.h
@@ -10,6 +10,8 @@
 #include "FairRootManager.h"
 #include "FairTask.h"
 
+#include "TH2.h"
+#include "TFile.h"
 #include "TCanvas.h"
 #include "TClonesArray.h"
 


### PR DESCRIPTION
This PR fix missing includes on some headers in AtEventDisplay folder and sets number of tracks maximum to display after digitalization to 20.