### PR TITLE
Add missing functions/enums to linkdefs

### DIFF
--- a/AtData/AtDataLinkDef.h
+++ b/AtData/AtDataLinkDef.h
@@ -25,4 +25,6 @@
 #pragma link C++ class AtPatterns::AtPatternCircle2D + ;
 #pragma link C++ class AtPatterns::AtPatternY + ;
 #pragma link C++ enum AtPatterns::PatternType;
+#pragma link C++ function AtPatterns::CreatePattern;
+
 #endif

--- a/AtReconstruction/AtReconstructionLinkDef.h
+++ b/AtReconstruction/AtReconstructionLinkDef.h
@@ -27,6 +27,8 @@
 
 #pragma link C++ namespace SampleConsensus;
 #pragma link C++ class SampleConsensus::AtSampleConsensus - !;
+#pragma link C++ class SampleConsensus::AtEstimator - !;
+#pragma link C++ enum SampleConsensus::Estimators;
 
 /* Classes that depend on Genfit2 */
 #pragma link C++ class genfit::AtSpacepointMeasurement + ;

--- a/AtTools/AtToolsLinkDef.h
+++ b/AtTools/AtToolsLinkDef.h
@@ -29,4 +29,7 @@
 #pragma link C++ class RandomSample::AtWeightedGaussian - !;
 #pragma link C++ class RandomSample::AtWeightedY - !;
 
+#pragma link C++ enum RandomSample::SampleMethod;
+#pragma link C++ function RandomSample::CreateSampler;
+
 #endif


### PR DESCRIPTION
Should allow for full ROOT terminal support of the SampleConsensus
module with automatic library loading. Fixes issue #124 