### PR TITLE
Fix bug where random sampling was biased towards specific hits

### DIFF
--- a/AtTools/AtHitSampling/AtSample.h
+++ b/AtTools/AtHitSampling/AtSample.h
@@ -61,6 +61,9 @@ protected:
 
    std::vector<int> sampleIndicesFromCDF(int N, std::vector<int> vetoed = {});
    int getIndexFromCDF(double r, double rmCFD, std::vector<int> vetoed);
+
+   double getPDFfromCDF(int index);
+
    template <typename T>
    static inline bool isInVector(T val, std::vector<T> vec)
    {


### PR DESCRIPTION
This only occured when some number of hits were vetoed from the pool
to sample. The CDF was not being properly adjusted to account for the
veoted hits.