### PR TITLE
Add task for sample consensus and clean AtPatternTask

### DIFF
--- a/AtData/AtDataLinkDef.h
+++ b/AtData/AtDataLinkDef.h
@@ -22,6 +22,7 @@
 
 #pragma link C++ class AtPatterns::AtPattern + ;
 #pragma link C++ class AtPatterns::AtPatternLine + ;
+#pragma link C++ class AtPatterns::AtPatternRay + ;
 #pragma link C++ class AtPatterns::AtPatternCircle2D + ;
 #pragma link C++ class AtPatterns::AtPatternY + ;
 #pragma link C++ enum AtPatterns::PatternType;

--- a/AtData/AtPattern/AtPattern.h
+++ b/AtData/AtPattern/AtPattern.h
@@ -16,6 +16,7 @@ class TBuffer;
 class TClass;
 class TMemberInspector;
 class TEveLine;
+class TEveElement;
 class AtHit;
 
 /**
@@ -68,9 +69,18 @@ public:
    virtual void DefinePattern(const std::vector<XYZPoint> &points) = 0;
 
    /**
+    * @brief Define based on parameters.
+    *
+    * Sets up the pattern according to the passed parameters. The internal implementation of
+    * what these parameters mean may change. It is the inverse operation of GetPatternPar()
+    */
+   virtual void DefinePattern(std::vector<double> par) { fPatternPar = std::move(par); }
+
+   /**
     * @brief Closest distance to pattern.
     *
     * @param[in] point Point to get the distance from.
+    * @return distance from point to pattern in mm.
     */
    virtual Double_t DistanceToPattern(const XYZPoint &point) const = 0;
    /**
@@ -106,7 +116,7 @@ public:
     *
     * Calls GetEveLine(double tMin, double tMax, int n) with reasonable defaults for the shape
     */
-   virtual TEveLine *GetEveLine() const = 0;
+   virtual TEveElement *GetEveElement() const = 0;
 
    virtual std::unique_ptr<AtPattern> Clone() const = 0;
 
@@ -118,8 +128,14 @@ public:
    Int_t GetNumPoints() const { return fNumPoints; }
    Double_t GetChi2() const { return fChi2; }
    Int_t GetNFree() const { return fNFree; }
-   std::vector<double> GetPatternPar() const { return fPatternPar; }
-   void SetPatternPar(std::vector<double> par) { fPatternPar = std::move(par); }
+
+   /**
+    * @brief Get list or parameters that describe the pattern.
+    *
+    * It is the inverse operation of DefinePattern(std::vector<double>)
+    */
+   virtual std::vector<double> GetPatternPar() const { return fPatternPar; }
+
    void SetChi2(double chi2) { fChi2 = chi2; }
 
 protected:

--- a/AtData/AtPattern/AtPatternCircle2D.cxx
+++ b/AtData/AtPattern/AtPatternCircle2D.cxx
@@ -6,17 +6,18 @@
 #include <Math/Vector2D.h>    // for DisplacementVector2D
 #include <Math/Vector3D.h>    // for DisplacementVector3D
 #include <Math/Vector3Dfwd.h> // for RhoZPhiVector
+#include <TEveLine.h>
 
 #include <algorithm> // for max
 #include <cmath>     // for fabs, isfinite, sqrt
 #include <memory>    // for allocator_traits<>::value_type
-class TEveLine;
 
+class TEveElement;
 using XYPoint = ROOT::Math::XYPoint;
 using namespace AtPatterns;
 
 AtPatternCircle2D::AtPatternCircle2D() : AtPattern(3) {}
-TEveLine *AtPatternCircle2D::GetEveLine() const
+TEveElement *AtPatternCircle2D::GetEveElement() const
 {
    return AtPattern::GetEveLine(0, 2 * M_PI, 1000);
 }

--- a/AtData/AtPattern/AtPatternCircle2D.h
+++ b/AtData/AtPattern/AtPatternCircle2D.h
@@ -10,7 +10,7 @@
 #include <memory> // for make_unique, unique_ptr
 #include <vector> // for vector
 
-class TEveLine;
+class TEveElement;
 class TBuffer;
 class TClass;
 class TMemberInspector;
@@ -34,7 +34,7 @@ public:
    virtual Double_t DistanceToPattern(const XYZPoint &point) const override;
    virtual XYZPoint ClosestPointOnPattern(const XYZPoint &point) const override;
    virtual XYZPoint GetPointAt(double theta) const override;
-   virtual TEveLine *GetEveLine() const override;
+   virtual TEveElement *GetEveElement() const override;
    virtual std::unique_ptr<AtPattern> Clone() const override { return std::make_unique<AtPatternCircle2D>(*this); }
 
 protected:

--- a/AtData/AtPattern/AtPatternLine.cxx
+++ b/AtData/AtPattern/AtPatternLine.cxx
@@ -3,11 +3,13 @@
 #include <FairLogger.h>
 
 #include <Math/Vector3D.h> // for DisplacementVector3D, operator*
+#include <TEveLine.h>
 #include <TMath.h>
 
 #include <algorithm> // for min
 #include <cmath>     // for cos, sin, pow, sqrt, acos, atan, fabs
-class TEveLine;
+
+class TEveElement;
 
 using namespace AtPatterns;
 
@@ -15,7 +17,7 @@ ClassImp(AtPatternLine);
 
 AtPatternLine::AtPatternLine() : AtPattern(2) {}
 
-TEveLine *AtPatternLine::GetEveLine() const
+TEveElement *AtPatternLine::GetEveElement() const
 {
    return AtPattern::GetEveLine(0, 1000, 100);
 }
@@ -54,14 +56,9 @@ void AtPatternLine::DefinePattern(const std::vector<XYZPoint> &points)
 
    auto fPoint = points[0];
    auto fDirection = points[1] - points[0];
+   if (fDirection.Z() != 0)
+      fDirection /= fabs(fDirection.Z());
 
-   // If not perpendicular to z-axis rescale direction
-   /*if (fDirection.Z() != 0) {
-      auto tZ = -fPoint.Z() / fDirection.Z();
-      fPoint += fDirection * tZ;
-
-      fDirection /= fDirection.Z();
-      }*/
    fPatternPar = {fPoint.X(), fPoint.Y(), fPoint.Z(), fDirection.X(), fDirection.Y(), fDirection.Z()};
 }
 
@@ -167,7 +164,6 @@ void AtPatternLine::FitPattern(const std::vector<XYZPoint> &points, const std::v
    // First 3 are point1. Second 3 are point 2
    XYZPoint p1 = {Xm, Ym, Zm};
    XYZPoint p2 = {Xh, Yh, Zh};
-
    DefinePattern({p1, p2});
    fChi2 = (fabs(dm2 / Q));
    fNFree = points.size() - 6;

--- a/AtData/AtPattern/AtPatternLine.h
+++ b/AtData/AtPattern/AtPatternLine.h
@@ -15,7 +15,7 @@
 class TBuffer;
 class TClass;
 class TMemberInspector;
-class TEveLine;
+class TEveElement;
 
 namespace AtPatterns {
 
@@ -37,7 +37,7 @@ public:
    virtual Double_t DistanceToPattern(const XYZPoint &point) const override;
    virtual XYZPoint ClosestPointOnPattern(const XYZPoint &point) const override;
    virtual XYZPoint GetPointAt(double z) const override;
-   virtual TEveLine *GetEveLine() const override;
+   virtual TEveElement *GetEveElement() const override;
    virtual std::unique_ptr<AtPattern> Clone() const override { return std::make_unique<AtPatternLine>(*this); }
 
 protected:

--- a/AtData/AtPattern/AtPatternRay.cxx
+++ b/AtData/AtPattern/AtPatternRay.cxx
@@ -1,0 +1,48 @@
+#include "AtPatternRay.h"
+
+#include "AtPattern.h" // for AtPattern, AtPatterns
+
+#include <Math/Point3D.h>  // for operator+, operator-
+#include <Math/Vector3D.h> // for DisplacementVector3D, operator*
+#include <TEveLine.h>
+
+#include <cmath> // for cos, sin, pow, sqrt, acos, atan, fabs
+
+class TEveElement;
+
+using namespace AtPatterns;
+
+ClassImp(AtPatternRay);
+
+AtPatternRay::AtPatternRay() : AtPatternLine() {}
+
+TEveElement *AtPatternRay::GetEveElement() const
+{
+   return AtPattern::GetEveLine(0, 1000, 100);
+}
+
+AtPatternRay::XYZPoint AtPatternRay::ClosestPointOnPattern(const XYZPoint &point) const
+{
+   auto t = parameterAtPoint(point);
+   return GetPointAt(t);
+}
+
+Double_t AtPatternRay::DistanceToPattern(const XYZPoint &point) const
+{
+   auto vec = ClosestPointOnPattern(point) - point;
+   return vec.R();
+}
+
+AtPatternRay::XYZPoint AtPatternRay::GetPointAt(double z) const
+{
+   if (z > 0)
+      return GetPoint() + z * GetDirection();
+   else
+      return GetPoint();
+}
+void AtPatternRay::DefinePattern(XYZPoint fPoint, XYZVector fDirection)
+{
+   if (fDirection.Z() != 0)
+      fDirection /= fabs(fDirection.Z());
+   fPatternPar = {fPoint.X(), fPoint.Y(), fPoint.Z(), fDirection.X(), fDirection.Y(), fDirection.Z()};
+}

--- a/AtData/AtPattern/AtPatternRay.h
+++ b/AtData/AtPattern/AtPatternRay.h
@@ -1,0 +1,44 @@
+#ifndef ATPATTERNRAY_H
+#define ATPATTERNRAY_H
+
+#include "AtPatternLine.h"
+
+#include <Rtypes.h> // for THashConsistencyHolder, ClassDefOverride
+
+#include <memory> // for make_unique, unique_ptr
+#include <vector> // for vector
+
+class TBuffer;
+class TClass;
+class TEveElement;
+class TMemberInspector;
+
+namespace AtPatterns {
+class AtPattern;
+}
+
+namespace AtPatterns {
+
+/**
+ * @brief Describes a linear track with an end point.
+ *
+ * @ingroup AtPattern
+ */
+class AtPatternRay : public AtPatternLine {
+public:
+   AtPatternRay();
+
+   void DefinePattern(XYZPoint point, XYZVector direction);
+   virtual void DefinePattern(const std::vector<XYZPoint> &points) override { AtPatternLine::DefinePattern(points); }
+   virtual Double_t DistanceToPattern(const XYZPoint &point) const override;
+   virtual XYZPoint ClosestPointOnPattern(const XYZPoint &point) const override;
+   virtual XYZPoint GetPointAt(double z) const override;
+   virtual TEveElement *GetEveElement() const override;
+   virtual std::unique_ptr<AtPattern> Clone() const override { return std::make_unique<AtPatternRay>(*this); }
+
+   ClassDefOverride(AtPatternRay, 1)
+};
+
+} // namespace AtPatterns
+
+#endif //#ifndef ATPATTERNRAY_H

--- a/AtData/AtPattern/AtPatternTypes.cxx
+++ b/AtData/AtPattern/AtPatternTypes.cxx
@@ -2,6 +2,7 @@
 
 #include "AtPatternCircle2D.h"
 #include "AtPatternLine.h"
+#include "AtPatternRay.h"
 #include "AtPatternY.h"
 
 using namespace AtPatterns;
@@ -11,6 +12,7 @@ std::unique_ptr<AtPattern> AtPatterns::CreatePattern(PatternType type)
 
    switch (type) {
    case (PatternType::kLine): return std::make_unique<AtPatternLine>();
+   case (PatternType::kRay): return std::make_unique<AtPatternRay>();
    case (PatternType::kCircle2D): return std::make_unique<AtPatternCircle2D>();
    case (PatternType::kY): return std::make_unique<AtPatternY>();
    default: return nullptr;

--- a/AtData/AtPattern/AtPatternTypes.h
+++ b/AtData/AtPattern/AtPatternTypes.h
@@ -11,7 +11,7 @@ namespace AtPatterns {
  * Can be created with the static factory AtPatterns::CreatePattern(PatternType type)
  * @ingroup AtPattern
  */
-enum class PatternType { kLine, kCircle2D, kY };
+enum class PatternType { kLine, kRay, kCircle2D, kY };
 
 class AtPattern;
 /**

--- a/AtData/AtPattern/AtPatternY.h
+++ b/AtData/AtPattern/AtPatternY.h
@@ -2,6 +2,7 @@
 #define ATPATTERNY_H
 
 #include "AtPattern.h"
+#include "AtPatternRay.h"
 
 #include <Math/Point3D.h>
 #include <Math/Point3Dfwd.h>  // for XYZPoint
@@ -9,9 +10,10 @@
 #include <Math/Vector3Dfwd.h> // for XYZVector
 #include <Rtypes.h>           // for THashConsistencyHolder, ClassDefOverride
 
+#include <array>
 #include <memory> // for make_unique, unique_ptr
 #include <vector> // for vector
-class TEveLine;
+class TEveElement;
 
 class TBuffer;
 class TClass;
@@ -25,23 +27,46 @@ namespace AtPatterns {
  * @ingroup AtPattern
  */
 class AtPatternY : public AtPattern {
+protected:
+   AtPatternRay fBeam;
+   std::array<AtPatternRay, 2> fFragments;
+
 public:
    using XYZPoint = ROOT::Math::XYZPoint;
    using XYZVector = ROOT::Math::XYZVector;
    AtPatternY();
 
-   XYZPoint GetVertex() const { return {fPatternPar[0], fPatternPar[1], fPatternPar[2]}; }
-   XYZVector GetDirection(int line) const;
+   /**
+    * @brief Get the vertex of the Y shape.
+    */
+   XYZPoint GetVertex() const { return fBeam.GetPoint(); }
+
+   /**
+    * @brief Get the direction of the beam ray.
+    * @return Direction of beam (points from vertex to window).
+    */
+   XYZVector GetBeamDirection() const { return fBeam.GetDirection(); }
+
+   /**
+    * @brief Get the direction of the fragment rays.
+    * @param[in] frag ID of the fragment (0 or 1)
+    * @return Direction of fragment (points away from vertex).
+    */
+   XYZVector GetFragmentDirection(int frag) const { return fFragments.at(frag).GetDirection(); }
 
    virtual void DefinePattern(const std::vector<XYZPoint> &points) override;
+   virtual void DefinePattern(std::vector<double> par) override;
    virtual Double_t DistanceToPattern(const XYZPoint &point) const override;
    virtual XYZPoint ClosestPointOnPattern(const XYZPoint &point) const override;
    virtual XYZPoint GetPointAt(double z) const override;
-   virtual TEveLine *GetEveLine() const override;
+   virtual TEveElement *GetEveElement() const override;
    virtual std::unique_ptr<AtPattern> Clone() const override { return std::make_unique<AtPatternY>(*this); }
+   virtual std::vector<double> GetPatternPar() const override;
 
 protected:
    virtual void FitPattern(const std::vector<XYZPoint> &points, const std::vector<double> &charge) override;
+
+   void DefinePattern(const XYZPoint &vertex, const XYZVector &beamDir, const std::array<XYZVector, 2> &fragDir);
 
    ClassDefOverride(AtPatternY, 1)
 };

--- a/AtData/CMakeLists.txt
+++ b/AtData/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRCS
   AtPattern/AtPatternLine.cxx
   AtPattern/AtPatternCircle2D.cxx
   AtPattern/AtPatternY.cxx
+  AtPattern/AtPatternRay.cxx
   AtPattern/AtPatternTypes.cxx
   )
 

--- a/AtDigitization/AtPulseTask.h
+++ b/AtDigitization/AtPulseTask.h
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <type_traits> // for add_pointer_t
 #include <vector>
 
 class AtMap;

--- a/AtEventDisplay/AtEventDrawTask.h
+++ b/AtEventDisplay/AtEventDrawTask.h
@@ -35,6 +35,7 @@ class TH2Poly;         // lines 41-41
 class TH3F;            // lines 42-42
 class TMemberInspector;
 class TPaletteAxis; // lines 43-43
+class TEveElement;
 
 class AtEventDrawTask : public FairTask {
 protected:
@@ -45,6 +46,7 @@ protected:
    TString fRawEventBranchName;
    TString fEventBranchName;
    TString fCorrectedEventBranchName;
+   TString fPatternEventBranchName;
 
    TClonesArray *fEventArray;
    TClonesArray *fCorrectedEventArray{};
@@ -133,7 +135,6 @@ protected:
    Float_t f3DThreshold;
 
    Bool_t fIsRawData;
-   Bool_t fRansacUnified;
    AtHit const *fIniHit;
    AtHit const *fIniHitRansac;
 
@@ -148,7 +149,7 @@ protected:
    */
    std::vector<TEvePointSet *> fHitSetTFHC;  // for TrackFinderHC
    std::vector<TEveBoxSet *> fHitClusterSet; // Track clusterization
-   std::vector<TEveLine *> fHitLine;         // Track line
+   std::vector<TEveElement *> fHitLine;      // Track line
 
    TEveRGBAPalette *fRGBAPalette;
 
@@ -170,16 +171,13 @@ public:
    void Set3DHitStyleBar();
    void Set3DHitStyleBox();
    void SetSaveTextData();
-   void SetLine(double t, std::vector<Double_t> p, double &x, double &y, double &z);
-   void SetLine6(double t, std::vector<Double_t> p, double &x, double &y, double &z);
    void SetRawEventBranch(TString branchName);
    void SetEventBranch(TString branchName);
    void SetCorrectedEventBranch(TString branchName) { fCorrectedEventBranchName = branchName; }
-
+   void SetPatternEventBranch(TString branchName) { fPatternEventBranchName = branchName; }
    static void SelectPad(const char *rawevt);
    void DrawWave(Int_t PadNum);
    void SetMultiHit(Int_t hitMax);
-   void SetUnifiedRansac(Bool_t val) { fRansacUnified = val; };
 
 private:
    void DrawPadPlane();

--- a/AtGenerators/AtTPCIonGenerator.cxx
+++ b/AtGenerators/AtTPCIonGenerator.cxx
@@ -20,8 +20,10 @@
 #include <TRandom.h>
 #include <TString.h>
 
+#include <algorithm> // for clamp
 #include <cmath>
 #include <iostream>
+#include <limits> // for numeric_limits
 
 constexpr auto cRED = "\033[1;31m";
 constexpr auto cYELLOW = "\033[1;33m";

--- a/AtGenerators/AtTPCIonGenerator.h
+++ b/AtGenerators/AtTPCIonGenerator.h
@@ -107,7 +107,7 @@ private:
    Double_t fPx, fPy, fPz;     // Momentum components [GeV] per nucleon
    Double32_t fR, fz, fOffset; // beam Spot radius [cm], z source, y source
    Double_t fVx, fVy, fVz;     // Vertex coordinates [cm]
-   Double_t fTheta;            // Maximum angle [rad]
+   Double_t fTheta{0};         // Maximum angle [rad]
    FairIon *fIon;              // Pointer to the FairIon to be generated
    Int_t fQ;                   // Electric charge [e]
    Int_t fNomEner{};

--- a/AtReconstruction/AtFitter/AtFitter.cxx
+++ b/AtReconstruction/AtFitter/AtFitter.cxx
@@ -7,13 +7,10 @@
 #include <Math/Point3D.h>  // for Cartesian3D, operator-, PositionVector3D
 #include <Math/Vector3D.h> // for DisplacementVector3D
 #include <TMath.h>
-#include <TMatrixDSymfwd.h> // for TMatrixDSym
-#include <TMatrixTSym.h>    // for TMatrixTSym
 
 #include <algorithm>
 #include <cmath>    // for sqrt
 #include <iostream> // for operator<<, basic_ostream::operator<<
-#include <iterator> // for back_insert_iterator, back_inserter
 #include <memory>   // for shared_ptr, __shared_ptr_access, __sha...
 #include <utility>  // for pair
 

--- a/AtReconstruction/AtFitter/AtFitter.h
+++ b/AtReconstruction/AtFitter/AtFitter.h
@@ -10,7 +10,6 @@
 #include <tuple>
 #include <vector>
 
-class AtTrackTransformer;
 class AtDigiPar;
 class AtTrack;
 class FairLogger;

--- a/AtReconstruction/AtFitterTask.h
+++ b/AtReconstruction/AtFitterTask.h
@@ -8,9 +8,9 @@
 #ifndef ATFITTERTASK
 #define ATFITTERTASK
 
-#include <Rtypes.h>
-// FAIRROOT classes
 #include <FairTask.h>
+
+#include <Rtypes.h>
 
 #include <cstddef>
 #include <string>

--- a/AtReconstruction/AtLinkDAQTask.cxx
+++ b/AtReconstruction/AtLinkDAQTask.cxx
@@ -7,6 +7,7 @@
 #include <FairRootFileSink.h>
 #include <FairRootManager.h>
 #include <FairRunAna.h>
+#include <FairSink.h> // for FairSink
 #include <FairTask.h>
 
 #include <TChain.h>

--- a/AtReconstruction/AtPatternRecognition/AtPRA.cxx
+++ b/AtReconstruction/AtPatternRecognition/AtPRA.cxx
@@ -1,8 +1,7 @@
 #include "AtPRA.h"
 
-#include "AtHit.h"        // for AtHit, XYZPoint
-#include "AtHitCluster.h" // for AtHitCluster
-#include "AtPattern.h"    // for AtPattern
+#include "AtHit.h"     // for AtHit, XYZPoint
+#include "AtPattern.h" // for AtPattern
 #include "AtPatternCircle2D.h"
 #include "AtPatternEvent.h"
 #include "AtPatternLine.h"
@@ -16,21 +15,15 @@
 #include <Math/Vector2D.h>    // for PositionVector3D, Cart...
 #include <Math/Vector2Dfwd.h> // for XYVector
 #include <Math/Vector3D.h>    // for DisplacementVector3D
-#include <TF1.h>              // for TF1
 #include <TGraph.h>           // for TGraph
 #include <TMath.h>            // for Power, Sqrt, ATan2, Pi
-#include <TMatrixDSymfwd.h>   // for TMatrixDSym
-#include <TMatrixTSym.h>      // for TMatrixTSym
-#include <TVector3.h>         // for TVector3
 
-#include <algorithm>          // for max, for_each, copy_if
-#include <cmath>              // for fabs, acos
-#include <cstddef>            // for size_t
-#include <exception>          // for exception
-#include <ext/alloc_traits.h> // for __alloc_traits<>::valu...
-#include <iostream>           // for operator<<, basic_ostream
-#include <iterator>           // for back_insert_iterator
-#include <memory>             // for shared_ptr, __shared_p...
+#include <algorithm> // for max, for_each, copy_if
+#include <cmath>     // for fabs, acos
+#include <cstddef>   // for size_t
+#include <exception> // for exception
+#include <iostream>  // for operator<<, basic_ostream
+#include <memory>    // for shared_ptr, __shared_p...
 
 ClassImp(AtPATTERN::AtPRA);
 

--- a/AtReconstruction/AtPatternRecognition/AtSampleConsensus.h
+++ b/AtReconstruction/AtPatternRecognition/AtSampleConsensus.h
@@ -57,7 +57,7 @@ private:
 
    float fIterations{500};       //< Number of interations of sample consensus
    float fMinPatternPoints{30};  //< Required number of points to form a pattern
-   float fDistanceThreshold{15}; //< Distance a point must be from pattern to be an inlier
+   float fDistanceThreshold{15}; //< Distance a point must be from pattern to be an inlier [mm]
    bool fFitPattern{true};
    /**
     * @brief Min charge for charge weighted fit.

--- a/AtReconstruction/AtPatternRecognition/AtTrackFinderTC.h
+++ b/AtReconstruction/AtPatternRecognition/AtTrackFinderTC.h
@@ -20,6 +20,7 @@
 #include <memory> // for unique_ptr
 #include <vector> // for vector
 
+class PointCloud;
 class AtEvent;
 class AtPatternEvent;
 class TBuffer;

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/cluster.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/cluster.cxx
@@ -10,9 +10,15 @@
 
 #include "cluster.h"
 
+#include "pointcloud.h" // for PointCloud, Point
+#include "triplet.h"    // for triplet, ScaleTripletMetric
+
 #include <algorithm>
 #include <cmath>
-#include <fstream>
+#include <iostream> // for operator<<, basic_ostream, endl, ofs...
+#include <iterator> // for distance
+#include <memory>   // for allocator_traits<>::value_type
+#include <set>      // for set, operator!=, operator==, set<>::...
 
 #include "hclust/fastcluster.h"
 

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/cluster.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/cluster.h
@@ -11,11 +11,14 @@
 #ifndef CLUSTER_H
 #define CLUSTER_H
 
-#include "triplet.h"
 #include "util.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
+
+class PointCloud;
+struct triplet;
 
 typedef std::vector<size_t> cluster_t;
 

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/dnn.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/dnn.cxx
@@ -9,7 +9,11 @@
 
 #include "dnn.h"
 
+#include "pointcloud.h" // for PointCloud
+
 #include <algorithm>
+#include <cstddef> // for size_t
+#include <memory>  // for allocator_traits<>::value_type
 #include <numeric>
 #include <vector>
 

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/dnn.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/dnn.h
@@ -9,7 +9,7 @@
 
 #ifndef DNN_H
 #define DNN_H
-#include "pointcloud.h"
+class PointCloud;
 
 // compute first quartile of the mean squared distance from the points
 double first_quartile(const PointCloud &cloud);

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/graph.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/graph.cxx
@@ -10,9 +10,10 @@
 
 #include "graph.h"
 
-#include <time.h>
+#include "pointcloud.h" // for Point, PointCloud
 
 #include <algorithm>
+#include <memory> // for allocator_traits<>::value_type
 #include <stack>
 
 struct Edge {

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/graph.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/graph.h
@@ -10,7 +10,7 @@
 
 #ifndef MSD_H
 #define MSD_H
-#include "pointcloud.h"
+class PointCloud;
 
 #include <cstddef>
 #include <vector>

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/hclust/fastcluster_dm.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/hclust/fastcluster_dm.cxx
@@ -362,7 +362,7 @@ public:
 
    t_index Find(t_index idx) const
    {
-      if (parent[idx] != 0) { // a → b
+      if (parent[idx] != 0) { // NOLINT a → b
          t_index p = idx;
          idx = parent[idx];
          if (parent[idx] != 0) { // a → b → c

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/kdtree/kdtree.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/kdtree/kdtree.cxx
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 
 namespace Kdtree {
@@ -200,7 +201,7 @@ KdTree::~KdTree()
    delete distance;
 }
 // distance_type can be 0 (Maximum), 1 (Manhatten), or 2 (Euklidean)
-KdTree::KdTree(const KdNodeVector *nodes, int distance_type /*=2*/)
+KdTree::KdTree(const KdNodeVector *nodes, int distance_type_ /*=2*/)
 {
    size_t i, j;
    double val;
@@ -210,7 +211,7 @@ KdTree::KdTree(const KdNodeVector *nodes, int distance_type /*=2*/)
    // initialize distance values
    distance = NULL;
    this->distance_type = -1;
-   set_distance(distance_type);
+   set_distance(distance_type_);
    // compute global bounding box
    lobound = nodes->begin()->point;
    upbound = nodes->begin()->point;
@@ -228,14 +229,14 @@ KdTree::KdTree(const KdNodeVector *nodes, int distance_type /*=2*/)
 }
 
 // distance_type can be 0 (Maximum), 1 (Manhatten), or 2 (Euklidean)
-void KdTree::set_distance(int distance_type, const DoubleVector *weights /*=NULL*/)
+void KdTree::set_distance(int distance_type_, const DoubleVector *weights /*=NULL*/)
 {
    if (distance)
       delete distance;
-   this->distance_type = distance_type;
-   if (distance_type == 0) {
+   this->distance_type = distance_type_;
+   if (distance_type_ == 0) {
       distance = (DistanceMeasure *)new DistanceL0(weights);
-   } else if (distance_type == 1) {
+   } else if (distance_type_ == 1) {
       distance = (DistanceMeasure *)new DistanceL1(weights);
    } else {
       distance = (DistanceMeasure *)new DistanceL2(weights);
@@ -254,7 +255,7 @@ kdtree_node *KdTree::build_tree(size_t depth, size_t a, size_t b)
    kdtree_node *node = new kdtree_node();
    node->lobound = lobound;
    node->upbound = upbound;
-   node->cutdim = depth % dimension;
+   node->cutdim = depth % dimension; // NOLINT
    if (b - a <= 1) {
       node->dataindex = a;
       node->point = allnodes[a].point;
@@ -349,7 +350,6 @@ void KdTree::k_nearest_neighbors(const CoordPoint &point, size_t k, KdNodeVector
 //--------------------------------------------------------------
 void KdTree::range_nearest_neighbors(const CoordPoint &point, double r, KdNodeVector *result)
 {
-   size_t i, k;
    KdNode temp;
 
    result->clear();

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/kdtree/kdtree.hpp
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/kdtree/kdtree.hpp
@@ -13,7 +13,6 @@
 #include <cstdlib>
 #include <queue>
 #include <vector>
-
 namespace Kdtree {
 
 typedef std::vector<double> CoordPoint;
@@ -21,13 +20,14 @@ typedef std::vector<double> DoubleVector;
 
 // for passing points to the constructor of kdtree
 struct KdNode {
-  CoordPoint point;
-  void* data;
-  KdNode(const CoordPoint& p, void* d = NULL) {
-    point = p;
-    data = d;
-  }
-  KdNode() { data = NULL; }
+   CoordPoint point;
+   void *data;
+   KdNode(const CoordPoint &p, void *d = NULL)
+   {
+      point = p;
+      data = d;
+   }
+   KdNode() { data = NULL; }
 };
 typedef std::vector<KdNode> KdNodeVector;
 
@@ -36,8 +36,8 @@ typedef std::vector<KdNode> KdNodeVector;
 // To define an own search predicate, derive from this class
 // and overwrite the call operator operator()
 struct KdNodePredicate {
-  virtual ~KdNodePredicate() {}
-  virtual bool operator()(const KdNode& kn) const { return true; }
+   virtual ~KdNodePredicate() {}
+   virtual bool operator()(const KdNode &kn) const { return true; }
 };
 
 //--------------------------------------------------------
@@ -49,61 +49,55 @@ class kdtree_node;
 class DistanceMeasure;
 // helper class for priority queue in k nearest neighbor search
 class nn4heap {
- public:
-  size_t dataindex;  // index of actual kdnode in *allnodes*
-  double distance;   // distance of this neighbor from *point*
-  nn4heap(size_t i, double d) {
-    dataindex = i;
-    distance = d;
-  }
+public:
+   size_t dataindex; // index of actual kdnode in *allnodes*
+   double distance;  // distance of this neighbor from *point*
+   nn4heap(size_t i, double d)
+   {
+      dataindex = i;
+      distance = d;
+   }
 };
 class compare_nn4heap {
- public:
-  bool operator()(const nn4heap& n, const nn4heap& m) {
-    return (n.distance < m.distance);
-  }
+public:
+   bool operator()(const nn4heap &n, const nn4heap &m) { return (n.distance < m.distance); }
 };
 //--------------------------------------------------------
 
 // kdtree class
 class KdTree {
- private:
-  // recursive build of tree
-  kdtree_node* build_tree(size_t depth, size_t a, size_t b);
-  // helper variable for keeping track of subtree bounding box
-  CoordPoint lobound, upbound;
-  // helper variables and functions for k nearest neighbor search
-  std::priority_queue<nn4heap, std::vector<nn4heap>, compare_nn4heap>*
-      neighborheap;
-  std::vector<size_t> range_result;
-  // helper variable to check the distance method
-  int distance_type;
-  bool neighbor_search(const CoordPoint& point, kdtree_node* node, size_t k);
-  void range_search(const CoordPoint& point, kdtree_node* node, double r);
-  bool bounds_overlap_ball(const CoordPoint& point, double dist,
-                           kdtree_node* node);
-  bool ball_within_bounds(const CoordPoint& point, double dist,
-                          kdtree_node* node);
-  // class implementing the distance computation
-  DistanceMeasure* distance;
-  // search predicate in knn searches
-  KdNodePredicate* searchpredicate;
+private:
+   // recursive build of tree
+   kdtree_node *build_tree(size_t depth, size_t a, size_t b);
+   // helper variable for keeping track of subtree bounding box
+   CoordPoint lobound, upbound;
+   // helper variables and functions for k nearest neighbor search
+   std::priority_queue<nn4heap, std::vector<nn4heap>, compare_nn4heap> *neighborheap;
+   std::vector<size_t> range_result;
+   // helper variable to check the distance method
+   int distance_type;
+   bool neighbor_search(const CoordPoint &point, kdtree_node *node, size_t k);
+   void range_search(const CoordPoint &point, kdtree_node *node, double r);
+   bool bounds_overlap_ball(const CoordPoint &point, double dist, kdtree_node *node);
+   bool ball_within_bounds(const CoordPoint &point, double dist, kdtree_node *node);
+   // class implementing the distance computation
+   DistanceMeasure *distance;
+   // search predicate in knn searches
+   KdNodePredicate *searchpredicate;
 
- public:
-  KdNodeVector allnodes;
-  size_t dimension;
-  kdtree_node* root;
-  // distance_type can be 0 (max), 1 (city block), or 2 (euklid)
-  KdTree(const KdNodeVector* nodes, int distance_type = 2);
-  ~KdTree();
-  void set_distance(int distance_type, const DoubleVector* weights = NULL);
-  void k_nearest_neighbors(const CoordPoint& point, size_t k,
-                           KdNodeVector* result, std::vector<double>* distances,
-                           KdNodePredicate* pred = NULL);
-  void range_nearest_neighbors(const CoordPoint& point, double r,
-                               KdNodeVector* result);
+public:
+   KdNodeVector allnodes;
+   size_t dimension;
+   kdtree_node *root;
+   // distance_type can be 0 (max), 1 (city block), or 2 (euklid)
+   KdTree(const KdNodeVector *nodes, int distance_type = 2);
+   ~KdTree();
+   void set_distance(int distance_type, const DoubleVector *weights = NULL);
+   void k_nearest_neighbors(const CoordPoint &point, size_t k, KdNodeVector *result, std::vector<double> *distances,
+                            KdNodePredicate *pred = NULL);
+   void range_nearest_neighbors(const CoordPoint &point, double r, KdNodeVector *result);
 };
 
-}  // end namespace Kdtree
+} // end namespace Kdtree
 
 #endif

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/main.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/main.cxx
@@ -13,11 +13,14 @@
 #include "option.h"
 #include "output.h"
 #include "pointcloud.h"
+#include "triplet.h" // for triplet, generate_triplets
 
 #include <cmath>
+#include <exception> // for exception
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <string> // for operator+, basic_string, string
 #include <vector>
 
 // usage message

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/option.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/option.cxx
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
 
 // initialize default values
 Opt::Opt()
@@ -180,13 +181,13 @@ int Opt::parse_args(int argc, char **argv)
          } else if (0 == strcmp(argv[i], "-skip")) {
             ++i;
             if (i < argc) {
-               int tmp = atoi(argv[i]);
-               if (tmp < 0) {
+               int tmp2 = atoi(argv[i]);
+               if (tmp2 < 0) {
                   std::cerr << "[Error] skip takes only positive integers. parameter "
                                "is ignored!"
                             << std::endl;
                } else {
-                  this->skip = (size_t)tmp;
+                  this->skip = (size_t)tmp2;
                }
             } else {
                return 1;

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/output.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/output.cxx
@@ -9,12 +9,15 @@
 
 #include "output.h"
 
+#include "pointcloud.h" // for Point, PointCloud
 #include <stdint.h>
 
 #include <cstdlib>
-#include <iomanip>
+#include <iostream> // for operator<<, basic_ostream, basic_ostream<>::...
+#include <memory>   // for allocator_traits<>::value_type
 #include <set>
-#include <sstream>
+#include <sstream> // IWYU pragma: keep
+#include <string>  // for char_traits, operator<<, string
 #include <vector>
 
 //-------------------------------------------------------------------

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/output.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/output.h
@@ -10,7 +10,9 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 #include "cluster.h"
-#include "pointcloud.h"
+
+#include <vector>
+class PointCloud;
 
 // saves a PointCloud *cloud* as csv file.
 bool cloud_to_csv(const PointCloud &cloud, const char *fname = "debug_smoothed.csv");

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/pointcloud.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/pointcloud.cxx
@@ -13,8 +13,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <exception> // for exception
+#include <memory>    // for allocator_traits<>::value_type
 #include <numeric>
-#include <sstream>
+#include <sstream> // IWYU pragma: keep
 #include <stdexcept>
 #include <string>
 

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/pointcloud.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/pointcloud.h
@@ -9,13 +9,11 @@
 
 #ifndef POINTCLOUD_H
 #define POINTCLOUD_H
+#include <algorithm>
 #include <cstddef>
 #include <fstream>
-#include <iostream>
-#include <ostream>
 #include <set>
 #include <vector>
-
 // 3D point class.
 class Point {
 public:

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/triplet.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/triplet.cxx
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 
 #include "kdtree/kdtree.hpp"
 

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/triplet.h
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/triplet.h
@@ -13,7 +13,7 @@
 
 #include "pointcloud.h"
 
-#include <limits>
+#include <cstddef>
 #include <vector>
 
 // triplet of three points

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/util.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/util.cxx
@@ -11,6 +11,7 @@
 
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 //-------------------------------------------------------------------
 // converts *str* to double.

--- a/AtReconstruction/AtRansacTask.cxx
+++ b/AtReconstruction/AtRansacTask.cxx
@@ -115,7 +115,7 @@ void AtRansacTask::Exec(Option_t *opt)
 
    auto sampleMethod = static_cast<RandomSample::SampleMethod>(fRandSamplMode);
    auto patternType = AtPatterns::PatternType::kLine;
-   auto estimator = SampleConsensus::Estimators::kRANSAC;
+   auto estimator = SampleConsensus::Estimators::kWRANSAC;
    if (fRANSACAlg == 2)
       estimator = SampleConsensus::Estimators::kMLESAC;
    if (fRANSACAlg == 3)

--- a/AtReconstruction/AtReconstructionLinkDef.h
+++ b/AtReconstruction/AtReconstructionLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class AtPSATBAvg + ;
 #pragma link C++ class AtPSAMax + ;
 #pragma link C++ class AtPSASimple2 + ;
+#pragma link C++ class AtPSAComposite - !;
 
 #pragma link C++ nestedclass;
 #pragma link C++ nestedtypedef;
@@ -41,6 +42,7 @@
 #pragma link C++ class AtPSAtask + ;
 #pragma link C++ class AtPRAtask + ;
 #pragma link C++ class AtRansacTask + ;
+#pragma link C++ class AtSampleConsensusTask + ;
 #pragma link C++ class AtDataReductionTask + ;
 #pragma link C++ class AtSpaceChargeCorrectionTask + ;
 #pragma link C++ class AtFilterTask + ;

--- a/AtReconstruction/AtSampleConsensusTask.cxx
+++ b/AtReconstruction/AtSampleConsensusTask.cxx
@@ -1,0 +1,57 @@
+#include "AtSampleConsensusTask.h"
+
+#include "AtEvent.h" // for AtEvent
+#include "AtPatternEvent.h"
+#include "AtSampleConsensus.h"
+
+#include <FairLogger.h>      // for LOG, Logger
+#include <FairRootManager.h> // for FairRootManager
+
+#include <TClonesArray.h> // for TClonesArray
+#include <TObject.h>      // for TObject
+
+#include <memory>  // for allocator
+#include <utility> // for move
+
+ClassImp(AtSampleConsensusTask);
+
+AtSampleConsensusTask::AtSampleConsensusTask(std::unique_ptr<SampleConsensus::AtSampleConsensus> method)
+   : fInputBranchName("AtEventH"), fOutputBranchName("AtPatternEvent"), fPatternEventArray("AtPatternEvent", 1),
+     fSampleConsensus(std::move(method)), kIsPersistence(kFALSE)
+{
+}
+
+InitStatus AtSampleConsensusTask::Init()
+{
+   FairRootManager *ioMan = FairRootManager::Instance();
+   if (ioMan == nullptr) {
+      LOG(error) << "Cannot find RootManager!";
+      return kERROR;
+   }
+
+   fEventArray = dynamic_cast<TClonesArray *>(ioMan->GetObject(fInputBranchName));
+   if (fEventArray == nullptr) {
+
+      LOG(error) << "Cannot find AtEvent array!";
+      return kERROR;
+   }
+
+   ioMan->Register(fOutputBranchName, "AtTPC", &fPatternEventArray, kIsPersistence);
+
+   return kSUCCESS;
+}
+
+void AtSampleConsensusTask::Exec(Option_t *opt)
+{
+
+   if (fEventArray->GetEntriesFast() == 0)
+      return;
+
+   fEvent = dynamic_cast<AtEvent *>(fEventArray->At(0));
+
+   LOG(debug) << "Running Sample Consensus with " << fEvent->GetNumHits() << " hits.";
+
+   fPatternEventArray.Delete();
+   auto patternEvent = fSampleConsensus->Solve(fEvent);
+   new (fPatternEventArray[0]) AtPatternEvent(patternEvent);
+}

--- a/AtReconstruction/AtSampleConsensusTask.h
+++ b/AtReconstruction/AtSampleConsensusTask.h
@@ -1,0 +1,45 @@
+#ifndef AtSAMPLECONSENSUSTASK_H
+#define AtSAMPLECONSENSUSTASK_H
+
+#include "AtSampleConsensus.h"
+
+#include <FairTask.h> // for FairTask, InitStatus
+
+#include <Rtypes.h> // for Int_t, Bool_t, Double_t, THashConsistencyHolder
+#include <TClonesArray.h>
+#include <TString.h> // for TString
+
+#include <memory> // for unique_ptr
+
+class AtEvent;
+class TBuffer;
+class TClass;
+class TMemberInspector;
+
+class AtSampleConsensusTask : public FairTask {
+private:
+   TString fInputBranchName;
+   TString fOutputBranchName;
+
+   TClonesArray *fEventArray{};
+   TClonesArray fPatternEventArray;
+
+   AtEvent *fEvent{};
+
+   std::unique_ptr<SampleConsensus::AtSampleConsensus> fSampleConsensus;
+   Bool_t kIsPersistence;
+
+public:
+   AtSampleConsensusTask(std::unique_ptr<SampleConsensus::AtSampleConsensus> method);
+
+   void SetInputBranch(TString branchName) { fInputBranchName = branchName; }
+   void SetOutputBranch(TString branchName) { fOutputBranchName = branchName; }
+   void SetPersistence(Bool_t value = kTRUE) { kIsPersistence = value; }
+
+   virtual InitStatus Init() override;
+   virtual void Exec(Option_t *opt) override;
+
+   ClassDefOverride(AtSampleConsensusTask, 1);
+};
+
+#endif // AtSAMPLECONSENSUSTASK_H

--- a/AtReconstruction/AtSpaceChargeCorrectionTask.cxx
+++ b/AtReconstruction/AtSpaceChargeCorrectionTask.cxx
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+class AtDigiPar;
 using XYZPoint = ROOT::Math::XYZPoint;
 
 ClassImp(AtSpaceChargeCorrectionTask);

--- a/AtReconstruction/CMakeLists.txt
+++ b/AtReconstruction/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SRCS
   AtPatternRecognition/AtSampleEstimator.cxx
   AtPatternRecognition/AtEstimatorMethods.cxx
   AtRansacTask.cxx
+  AtSampleConsensusTask.cxx
   AtPRAtask.cxx
 
   AtPatternRecognition/triplclust/src/cluster.cxx 

--- a/AtTools/AtHitSampling/AtWeightedY.cxx
+++ b/AtTools/AtHitSampling/AtWeightedY.cxx
@@ -3,6 +3,8 @@
 #include "AtHit.h"
 #include "AtSample.h" // for RandomSample
 
+#include <FairLogger.h> // for Logger, LOG
+
 #include <algorithm> // for max
 #include <cmath>     // for pow, sqrt
 #include <memory>    // for allocator_traits<>::value_type
@@ -12,9 +14,11 @@ using namespace RandomSample;
 std::vector<AtHit> AtWeightedY::SampleHits(int N)
 {
    std::vector<AtHit> ret;
+   LOG(debug) << "Vetoing " << fVetoIn.size();
 
    // If every hit is outside of the beam region, then skip the vetoed beam region
    if (fVetoIn.size() == fHits->size() || fVetoIn.size() == 0) {
+      LOG(error) << "Defaulting to normal sampling (fVetoIn is size: " << fVetoIn.size() << ")";
       for (auto ind : sampleIndicesFromCDF(N))
          ret.push_back(fHits->at(ind));
       return ret;
@@ -30,6 +34,8 @@ std::vector<AtHit> AtWeightedY::SampleHits(int N)
 void AtWeightedY::SetHitsToSample(const std::vector<AtHit> *hits)
 {
    fHits = hits;
+   fVetoOut.clear();
+   fVetoIn.clear();
    FillCDF();
    for (int i = 0; i < fHits->size(); i++) {
       if (sqrt(pow(fHits->at(i).GetPosition().X(), 2) + pow(fHits->at(i).GetPosition().Y(), 2)) < 20) {

--- a/AtTools/AtRadialChargeModel.cxx
+++ b/AtTools/AtRadialChargeModel.cxx
@@ -5,10 +5,16 @@
 #include <FairLogger.h>
 
 #include <Math/Point2D.h>
+#include <Math/Point2Dfwd.h> // for XYPoint
+#include <Math/Point3D.h>    // for PositionVector3D
+#include <Math/Point3Dfwd.h> // for RhoZPhiPoint, XYZPoint
 #include <Math/Vector2D.h>
+#include <Math/Vector2Dfwd.h> // for XYVector
 #include <Math/Vector3D.h>
+#include <Math/Vector3Dfwd.h> // for XYZVector
 
 #include <cmath>
+#include <memory> // for allocator
 
 constexpr auto c = 29979.2;  //< c in cm/us
 constexpr auto c2 = c * c;   //< c^2

--- a/AtTools/AtRadialChargeModel.h
+++ b/AtTools/AtRadialChargeModel.h
@@ -3,8 +3,12 @@
 
 #include "AtSpaceChargeModel.h"
 
-#include <Math/Point2Dfwd.h>
-#include <Math/Vector2Dfwd.h>
+#include <Rtypes.h> // for Double_t
+
+#include <type_traits> // for add_pointer_t
+
+class AtDigiPar;
+
 /**
  * @brief Space charge model from arbitrary radial E-field,
  *

--- a/AtTools/AtTrackTransformer.cxx
+++ b/AtTools/AtTrackTransformer.cxx
@@ -1,23 +1,20 @@
 #include "AtTrackTransformer.h"
 
-#include <Math/Point3D.h>     // for PositionVector3D, Cart...
-#include <Math/Vector2D.h>    // for PositionVector3D, Cart...
-#include <Math/Vector2Dfwd.h> // for XYVector
-#include <Math/Vector3D.h>    // for DisplacementVector3D
-#include <TGraph.h>           // for TGraph
-#include <TMath.h>            // for Power, Sqrt, ATan2, Pi
-#include <TMatrixDSymfwd.h>   // for TMatrixDSym
-#include <TMatrixTSym.h>      // for TMatrixTSym
-#include <TVector3.h>         // for TVector3
+#include "AtHit.h"        // for AtHit, AtHit::XYZPoint
+#include "AtHitCluster.h" // for AtHitCluster
+#include "AtTrack.h"      // for XYZPoint, AtTrack
 
-#include <algorithm>          // for max, for_each, copy_if
-#include <cmath>              // for fabs, acos
-#include <cstddef>            // for size_t
-#include <exception>          // for exception
-#include <ext/alloc_traits.h> // for __alloc_traits<>::valu...
-#include <iostream>           // for operator<<, basic_ostream
-#include <iterator>           // for back_insert_iterator
-#include <memory>             // for shared_ptr, __shared_p...
+#include <Math/Point3D.h>   // for PositionVector3D, Cart...
+#include <Math/Vector3D.h>  // for DisplacementVector3D
+#include <TMath.h>          // for Power, Sqrt, ATan2, Pi
+#include <TMatrixDSymfwd.h> // for TMatrixDSym
+#include <TMatrixTSym.h>    // for TMatrixTSym
+#include <TVector3.h>       // for TVector3
+
+#include <algorithm> // for max, for_each, copy_if
+#include <iterator>  // for back_insert_iterator
+#include <memory>    // for shared_ptr, __shared_p...
+#include <vector>    // for vector
 
 AtTools::AtTrackTransformer::AtTrackTransformer() = default;
 AtTools::AtTrackTransformer::~AtTrackTransformer() = default;

--- a/AtTools/AtTrackTransformer.h
+++ b/AtTools/AtTrackTransformer.h
@@ -1,20 +1,9 @@
 #ifndef ATTRACKTRANSFORMER_H
 #define ATTRACKTRANSFORMER_H
 
-#include "AtTrack.h"
-
 #include <Rtypes.h>
-#include <TObject.h>
-#include <TString.h>
 
-#include <ostream>
-#include <string>
-#include <vector>
-
-class TXMLNode;
-class TBuffer;
-class TClass;
-class TMemberInspector;
+class AtTrack;
 
 namespace AtTools {
 

--- a/macro/e12014/adam/helper.h
+++ b/macro/e12014/adam/helper.h
@@ -18,7 +18,7 @@
 #include "../build/include/AtAuxPad.h"
 #include "../build/include/AtEvent.h"
 #include "../build/include/AtPad.h"
-#include "../build/include/AtRansac.h"
+#include "../build/include/AtPatternEvent.h"
 #include "../build/include/AtRawEvent.h"
 #include "../build/include/AtTpcMap.h"
 #endif
@@ -26,7 +26,7 @@
 // "public functions"
 void loadRun(TString filePath, TString rawEventBranchName = "AtRawEvent",
              TString rawEventFilteredBranchName = "AtRawEventFiltered", TString eventBranchName = "AtEventFiltered",
-             TString ransacBranchName = "AtRansac");
+             TString patternBranchName = "AtPatternEvent");
 bool loadEvent(ULong64_t eventNumber);
 bool loadPad(int padNum);
 bool nextEvent();
@@ -35,7 +35,7 @@ bool nextEvent();
 AtRawEvent *rawEventPtr;
 AtRawEvent *rawEventFilteredPtr;
 AtEvent *eventPtr;
-AtRANSACN::AtRansac *ransacPtr;
+AtPatternEvent *patternEventPtr;
 AtTpcMap *tpcMap = nullptr;
 
 /***** "Private" variables *******/
@@ -44,12 +44,12 @@ TTreeReader *reader = nullptr;
 TTreeReaderValue<TClonesArray> *rawEventReader = nullptr;
 TTreeReaderValue<TClonesArray> *eventFilteredReader = nullptr;
 TTreeReaderValue<TClonesArray> *eventReader = nullptr;
-TTreeReaderValue<TClonesArray> *ransacReader = nullptr;
+TTreeReaderValue<TClonesArray> *patternEventReader = nullptr;
 
 TH1F *hTrace = new TH1F("trace", "Trace", 512, 0, 511);
 
 void loadRun(TString filePath, TString rawEventBranchName, TString rawEventFilteredBranchName, TString eventBranchName,
-             TString ransacBranchName)
+             TString patternEventBranchName)
 {
    if (tpcMap == nullptr) {
       tpcMap = new AtTpcMap();
@@ -85,12 +85,12 @@ void loadRun(TString filePath, TString rawEventBranchName, TString rawEventFilte
    else
       LOG(error) << "Could not find filtered raw event branch " << rawEventFilteredBranchName;
 
-   if (ransacReader != nullptr)
-      delete ransacReader;
-   if (tpcTree->GetBranch(ransacBranchName) != nullptr)
-      ransacReader = new TTreeReaderValue<TClonesArray>(*reader, ransacBranchName);
+   if (patternEventReader != nullptr)
+      delete patternEventReader;
+   if (tpcTree->GetBranch(patternEventBranchName) != nullptr)
+      patternEventReader = new TTreeReaderValue<TClonesArray>(*reader, patternEventBranchName);
    else
-      LOG(error) << "Could not find RANSAC branch " << ransacBranchName;
+      LOG(error) << "Could not find PATTERNEVENT branch " << patternEventBranchName;
    // loadEvent(0);
 }
 
@@ -106,8 +106,8 @@ bool loadEvent(ULong64_t eventNumber)
    eventPtr = dynamic_cast<AtEvent *>((*eventReader)->At(0));
    if (eventFilteredReader != nullptr)
       rawEventFilteredPtr = dynamic_cast<AtRawEvent *>((*eventFilteredReader)->At(0));
-   if (ransacReader != nullptr)
-      ransacPtr = dynamic_cast<AtRANSACN::AtRansac *>((*ransacReader)->At(0));
+   if (patternEventReader != nullptr)
+      patternEventPtr = dynamic_cast<AtPatternEvent *>((*patternEventReader)->At(0));
 
    return true;
 }
@@ -132,8 +132,8 @@ bool nextEvent()
    eventPtr = dynamic_cast<AtEvent *>((*eventReader)->At(0));
    if (eventFilteredReader != nullptr)
       rawEventFilteredPtr = dynamic_cast<AtRawEvent *>((*eventFilteredReader)->At(0));
-   if (ransacReader != nullptr)
-      ransacPtr = dynamic_cast<AtRANSACN::AtRansac *>((*ransacReader)->At(0));
+   if (patternEventReader != nullptr)
+      patternEventPtr = dynamic_cast<AtPatternEvent *>((*patternEventReader)->At(0));
 
    return ret;
 }


### PR DESCRIPTION
* Add new task for sample consensus (AtSampleConsensusTask)
* Added AtPatternRay, a pattern describing a ray from a point in a
given direction
* Implemented AtPatternY in terms of AtPatternRay. This should make it
easier to calculate the distance to the pattern properly. The old
method had a logic bug where you could conseavably get the wrong
answer (which line is closest is not soley determined by the z
location of the point we are comparing to)
* Add visualization for AtPatternRay and AtPatternY
* Change public interface of AtPatternY for getting direction so it is
more explicit what direction you are getting
* AtPatternY can now be minimized using a fitting procedure (like the
rest of the patterns)
* Run linters on all code