### PR TITLE
Add simple simulation task (bypass GEANT and use AtELossModels)

### DIFF
--- a/AtDigitization/AtDigiLinkDef.h
+++ b/AtDigitization/AtDigiLinkDef.h
@@ -14,5 +14,5 @@
 #pragma link C++ class AtTrigger + ;
 #pragma link C++ class AtTriggerTask + ;
 #pragma link C++ class AtVectorResponse - ;
-
+#pragma link C++ class AtTestSimulation + ;
 #endif

--- a/AtDigitization/AtDigiLinkDef.h
+++ b/AtDigitization/AtDigiLinkDef.h
@@ -15,4 +15,5 @@
 #pragma link C++ class AtTriggerTask + ;
 #pragma link C++ class AtVectorResponse - ;
 #pragma link C++ class AtTestSimulation + ;
+#pragma link C++ class AtSimpleSimulation - !;
 #endif

--- a/AtDigitization/AtSimpleSimulation.cxx
+++ b/AtDigitization/AtSimpleSimulation.cxx
@@ -6,9 +6,15 @@
 #include <FairLogger.h>
 #include <FairRootManager.h>
 
+#include <TClonesArray.h> // for TClonesArray
 #include <TGeoManager.h>
 #include <TGeoNode.h>
 #include <TGeoVolume.h>
+#include <TObject.h> // for TObject
+
+#include <cmath>     // for sqrt
+#include <stdexcept> // for invalid_argument
+#include <utility>   // for pair
 
 AtSimpleSimulation::AtSimpleSimulation(std::string geoFile)
 {
@@ -87,10 +93,9 @@ void AtSimpleSimulation::SimulateParticle(ModelPtr model, const XYZPoint &iniPos
 
    auto pos = iniPos;
    auto mom = iniMom;
-   auto m = iniMom.M();
-
    double length = 0;
 
+   // Need to also add a condition for when the particle stops in the detector...
    while (IsInVolume("drift_volume", pos)) {
 
       // Direction particle is traveling
@@ -145,8 +150,10 @@ void AtSimpleSimulation::AddHit(double ELoss, const XYZPoint &pos, const PxPyPzE
 void AtSimpleSimulation::Init(std::string branchName)
 {
    auto ioMan = FairRootManager::Instance();
-   if (ioMan == nullptr)
+   if (ioMan == nullptr) {
       LOG(fatal) << "The IO manager was not instatiated before attempting to simulate an event.";
+      return;
+   }
 
    fMCPoints = ioMan->Register(branchName, "AtMCPoint", "AtTPC", true);
 }

--- a/AtDigitization/AtSimpleSimulation.cxx
+++ b/AtDigitization/AtSimpleSimulation.cxx
@@ -1,0 +1,120 @@
+
+#include "AtSimpleSimulation.h"
+
+#include "AtMCPoint.h"
+
+#include <FairLogger.h>
+#include <FairRootManager.h>
+
+#include <TGeoManager.h>
+#include <TGeoNode.h>
+#include <TGeoVolume.h>
+
+bool AtSimpleSimulation::ParticleID::operator<(const ParticleID &other) const
+{
+   if (A < other.A) {
+      return true;
+   } else if (A > other.A) {
+      return false;
+   } else {
+      return Z < other.Z;
+   }
+}
+
+bool AtSimpleSimulation::IsInVolume(const std::string &volName, const XYZPoint &point)
+{
+   TGeoNode *node = gGeoManager->FindNode(point.X(), point.Y(), point.Z());
+   if (node == nullptr) {
+      return false;
+   }
+
+   TGeoVolume *volume = node->GetVolume();
+   if (volume == nullptr || volName != std::string(volume->GetName())) {
+      return false;
+   }
+
+   return true;
+}
+
+std::string AtSimpleSimulation::GetVolumeName(const XYZPoint &point)
+{
+   TGeoNode *node = gGeoManager->FindNode(point.X(), point.Y(), point.Z());
+   if (node == nullptr) {
+      return "";
+   }
+   TGeoVolume *volume = node->GetVolume();
+   if (volume == nullptr) {
+      return "";
+   }
+   return volume->GetName();
+}
+
+void AtSimpleSimulation::AddModel(int Z, int A, ModelPtr model)
+{
+   ParticleID id = {
+      .A = A,
+      .Z = Z,
+   };
+
+   fModels[id] = model;
+}
+
+void AtSimpleSimulation::SimulateParticle(int Z, int A, const XYZPoint &iniPos, const XYZVector &iniMom)
+{
+   auto modelIt = fModels.find({Z, A});
+   if (modelIt == fModels.end())
+      throw std::invalid_argument("Missing energy loss model for Z:" + std::to_string(Z) + " A:" + std::to_string(A));
+   if (!IsInVolume("drift_vol", iniPos))
+      throw std::invalid_argument("Position of particle is not in active volume");
+
+   SimulateParticle(modelIt->second, iniPos, iniMom);
+}
+
+void AtSimpleSimulation::SimulateParticle(ModelPtr model, const XYZPoint &iniPos, const XYZVector &iniMom)
+{
+   // This is a new track
+   fTrackID++;
+   auto pos = iniPos;
+   auto mom = iniMom;
+   double length = 0;
+
+   while (IsInVolume("drift_vol", pos)) {
+      double eLoss;
+      // Update the momentum from the energy loss model
+
+      pos += iniMom.Unit() * fDistStep;
+      length += fDistStep;
+      AddHit(eLoss, pos, mom, length);
+   }
+}
+
+AtSimpleSimulation::AtSimpleSimulation(bool isPersistant, std::string branchName)
+{
+   auto ioMan = FairRootManager::Instance();
+   if (ioMan == nullptr)
+      LOG(fatal) << "The IO manager was not instatiated before AtSimpleSimulation.";
+
+   ioMan->Register(branchName.c_str(), "AtTpc", &fMCPoints, isPersistant);
+}
+
+void AtSimpleSimulation::NewEvent()
+{
+   fMCPoints.Clear();
+   fTrackID = 0;
+}
+
+void AtSimpleSimulation::AddHit(double ELoss, const XYZPoint &pos, const XYZVector &mom, double length)
+{
+   auto *mcPoint = dynamic_cast<AtMCPoint *>(fMCPoints.ConstructedAt(fMCPoints.GetEntriesFast(), "C"));
+
+   mcPoint->SetTrackID(fTrackID);
+   mcPoint->SetLength(length);
+   mcPoint->SetEnergyLoss(ELoss);
+
+   // mcPoint->fEnergyIni = Eini;
+   // mcPoint->fAiso = A;
+   // mcPoint->fZiso = Z;
+
+   mcPoint->SetPosition(pos);
+   mcPoint->SetMomentum(mom);
+}

--- a/AtDigitization/AtSimpleSimulation.cxx
+++ b/AtDigitization/AtSimpleSimulation.cxx
@@ -92,9 +92,9 @@ AtSimpleSimulation::AtSimpleSimulation(bool isPersistant, std::string branchName
 {
    auto ioMan = FairRootManager::Instance();
    if (ioMan == nullptr)
-      LOG(fatal) << "The IO manager was not instatiated before AtSimpleSimulation.";
-
-   ioMan->Register(branchName.c_str(), "AtTpc", &fMCPoints, isPersistant);
+      LOG(error) << "The IO manager was not instatiated before AtSimpleSimulation.";
+   else
+      ioMan->Register(branchName.c_str(), "AtTpc", &fMCPoints, isPersistant);
 }
 
 void AtSimpleSimulation::NewEvent()

--- a/AtDigitization/AtSimpleSimulation.cxx
+++ b/AtDigitization/AtSimpleSimulation.cxx
@@ -10,6 +10,13 @@
 #include <TGeoNode.h>
 #include <TGeoVolume.h>
 
+AtSimpleSimulation::AtSimpleSimulation(std::string geoFile)
+{
+   TGeoManager *geo = TGeoManager::Import(geoFile.c_str());
+
+   if (gGeoManager == nullptr)
+      LOG(fatal) << "Failed to load geometry file " << geoFile << " " << geo;
+}
 bool AtSimpleSimulation::ParticleID::operator<(const ParticleID &other) const
 {
    if (A < other.A) {
@@ -21,14 +28,21 @@ bool AtSimpleSimulation::ParticleID::operator<(const ParticleID &other) const
    }
 }
 
+/// Takes position in mm
+TGeoVolume *AtSimpleSimulation::GetVolume(const XYZPoint &point)
+{
+   auto pointCm = point / 10.;
+   TGeoNode *node = gGeoManager->FindNode(pointCm.X(), pointCm.Y(), pointCm.Z());
+   if (node == nullptr) {
+      return nullptr;
+   }
+   return node->GetVolume();
+}
+
 bool AtSimpleSimulation::IsInVolume(const std::string &volName, const XYZPoint &point)
 {
-   TGeoNode *node = gGeoManager->FindNode(point.X(), point.Y(), point.Z());
-   if (node == nullptr) {
-      return false;
-   }
 
-   TGeoVolume *volume = node->GetVolume();
+   TGeoVolume *volume = GetVolume(point);
    if (volume == nullptr || volName != std::string(volume->GetName())) {
       return false;
    }
@@ -38,11 +52,7 @@ bool AtSimpleSimulation::IsInVolume(const std::string &volName, const XYZPoint &
 
 std::string AtSimpleSimulation::GetVolumeName(const XYZPoint &point)
 {
-   TGeoNode *node = gGeoManager->FindNode(point.X(), point.Y(), point.Z());
-   if (node == nullptr) {
-      return "";
-   }
-   TGeoVolume *volume = node->GetVolume();
+   TGeoVolume *volume = GetVolume(point);
    if (volume == nullptr) {
       return "";
    }
@@ -61,11 +71,11 @@ void AtSimpleSimulation::AddModel(int Z, int A, ModelPtr model)
 
 void AtSimpleSimulation::SimulateParticle(int Z, int A, const XYZPoint &iniPos, const XYZVector &iniMom)
 {
-   auto modelIt = fModels.find({Z, A});
+   auto modelIt = fModels.find({A, Z});
    if (modelIt == fModels.end())
       throw std::invalid_argument("Missing energy loss model for Z:" + std::to_string(Z) + " A:" + std::to_string(A));
-   if (!IsInVolume("drift_vol", iniPos))
-      throw std::invalid_argument("Position of particle is not in active volume");
+   if (!IsInVolume("drift_volume", iniPos))
+      throw std::invalid_argument("Position of particle is not in active volume but is in " + GetVolumeName(iniPos));
 
    SimulateParticle(modelIt->second, iniPos, iniMom);
 }
@@ -78,8 +88,8 @@ void AtSimpleSimulation::SimulateParticle(ModelPtr model, const XYZPoint &iniPos
    auto mom = iniMom;
    double length = 0;
 
-   while (IsInVolume("drift_vol", pos)) {
-      double eLoss;
+   while (IsInVolume("drift_volume", pos)) {
+      double eLoss = 100;
       // Update the momentum from the energy loss model
 
       pos += iniMom.Unit() * fDistStep;
@@ -88,33 +98,36 @@ void AtSimpleSimulation::SimulateParticle(ModelPtr model, const XYZPoint &iniPos
    }
 }
 
-AtSimpleSimulation::AtSimpleSimulation(bool isPersistant, std::string branchName)
-{
-   auto ioMan = FairRootManager::Instance();
-   if (ioMan == nullptr)
-      LOG(error) << "The IO manager was not instatiated before AtSimpleSimulation.";
-   else
-      ioMan->Register(branchName.c_str(), "AtTpc", &fMCPoints, isPersistant);
-}
-
 void AtSimpleSimulation::NewEvent()
 {
-   fMCPoints.Clear();
+   fMCPoints->Clear();
    fTrackID = 0;
 }
 
 void AtSimpleSimulation::AddHit(double ELoss, const XYZPoint &pos, const XYZVector &mom, double length)
 {
-   auto *mcPoint = dynamic_cast<AtMCPoint *>(fMCPoints.ConstructedAt(fMCPoints.GetEntriesFast(), "C"));
+   LOG(info) << "Adding a hit at element " << fMCPoints->GetEntriesFast() << " in TClonesArray.";
+
+   auto *mcPoint = dynamic_cast<AtMCPoint *>(fMCPoints->ConstructedAt(fMCPoints->GetEntriesFast(), "C"));
 
    mcPoint->SetTrackID(fTrackID);
-   mcPoint->SetLength(length);
-   mcPoint->SetEnergyLoss(ELoss);
+   mcPoint->SetLength(length / 10.);
+   mcPoint->SetEnergyLoss(ELoss / 1000.);
+   mcPoint->SetVolName("drift_volume");
 
    // mcPoint->fEnergyIni = Eini;
    // mcPoint->fAiso = A;
    // mcPoint->fZiso = Z;
-
-   mcPoint->SetPosition(pos);
+   mcPoint->SetPosition(pos / 10.);
    mcPoint->SetMomentum(mom);
+   mcPoint->Print(nullptr);
+}
+
+void AtSimpleSimulation::Init(std::string branchName)
+{
+   auto ioMan = FairRootManager::Instance();
+   if (ioMan == nullptr)
+      LOG(fatal) << "The IO manager was not instatiated before attempting to simulate an event.";
+
+   fMCPoints = ioMan->Register(branchName, "AtMCPoint", "AtTPC", true);
 }

--- a/AtDigitization/AtSimpleSimulation.h
+++ b/AtDigitization/AtSimpleSimulation.h
@@ -10,6 +10,7 @@
 namespace AtTools {
 class AtELossModel;
 }
+class TGeoVolume;
 
 /**
  * Class for simulating simple events using AtELossModels.
@@ -28,10 +29,10 @@ protected:
    using XYZVector = ROOT::Math::XYZVector;
 
    std::map<ParticleID, ModelPtr> fModels;
-   TClonesArray fMCPoints;
+   TClonesArray *fMCPoints{nullptr};
 
    // Variables to across an entire event
-   int fTrackID;
+   int fTrackID{0};
 
    double fDistStep{1.}; // Distance step in mm for particles
 
@@ -39,10 +40,11 @@ public:
    /**
     * Assumes that the IO manager has been initialized (it will attempt to construct the branch needed here).
     */
-   AtSimpleSimulation(bool isPersistant = true, std::string branchName = "AtTpcPoint");
+   AtSimpleSimulation(std::string geoFile);
 
    ~AtSimpleSimulation() = default;
 
+   void Init(std::string branchName = "AtTpcPoint");
    void AddModel(int Z, int A, ModelPtr model);
 
    void NewEvent();
@@ -54,6 +56,7 @@ protected:
 
    void SimulateParticle(ModelPtr model, const XYZPoint &iniPos, const XYZVector &iniMom);
    void AddHit(double ELoss, const XYZPoint &pos, const XYZVector &mom, double length);
+   TGeoVolume *GetVolume(const XYZPoint &pos);
 };
 
 #endif // AT_SIMPLE_SIMULATION_H

--- a/AtDigitization/AtSimpleSimulation.h
+++ b/AtDigitization/AtSimpleSimulation.h
@@ -2,12 +2,17 @@
 #define AT_SIMPLE_SIMULATION_H
 
 #include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h> // for XYZPoint
 #include <Math/Vector3D.h>
+#include <Math/Vector3Dfwd.h> // for XYZVector
 #include <Math/Vector4D.h>
-#include <TClonesArray.h>
+#include <Math/Vector4Dfwd.h> // for PxPyPzEVector
 
 #include <map>
 #include <memory>
+#include <string> // for string
+
+class TClonesArray;
 namespace AtTools {
 class AtELossModel;
 }

--- a/AtDigitization/AtSimpleSimulation.h
+++ b/AtDigitization/AtSimpleSimulation.h
@@ -7,7 +7,9 @@
 
 #include <map>
 #include <memory>
+namespace AtTools {
 class AtELossModel;
+}
 
 /**
  * Class for simulating simple events using AtELossModels.
@@ -21,7 +23,7 @@ protected:
 
       bool operator<(const ParticleID &other) const;
    };
-   using ModelPtr = std::shared_ptr<AtELossModel>;
+   using ModelPtr = std::shared_ptr<AtTools::AtELossModel>;
    using XYZPoint = ROOT::Math::XYZPoint;
    using XYZVector = ROOT::Math::XYZVector;
 

--- a/AtDigitization/AtSimpleSimulation.h
+++ b/AtDigitization/AtSimpleSimulation.h
@@ -3,6 +3,7 @@
 
 #include <Math/Point3D.h>
 #include <Math/Vector3D.h>
+#include <Math/Vector4D.h>
 #include <TClonesArray.h>
 
 #include <map>
@@ -27,6 +28,7 @@ protected:
    using ModelPtr = std::shared_ptr<AtTools::AtELossModel>;
    using XYZPoint = ROOT::Math::XYZPoint;
    using XYZVector = ROOT::Math::XYZVector;
+   using PxPyPzEVector = ROOT::Math::PxPyPzEVector;
 
    std::map<ParticleID, ModelPtr> fModels;
    TClonesArray *fMCPoints{nullptr};
@@ -48,14 +50,14 @@ public:
    void AddModel(int Z, int A, ModelPtr model);
 
    void NewEvent();
-   void SimulateParticle(int Z, int A, const XYZPoint &iniPos, const XYZVector &iniMom);
+   void SimulateParticle(int Z, int A, const XYZPoint &iniPos, const PxPyPzEVector &iniMom);
 
 protected:
    bool IsInVolume(const std::string &volName, const XYZPoint &point);
    std::string GetVolumeName(const XYZPoint &point);
 
-   void SimulateParticle(ModelPtr model, const XYZPoint &iniPos, const XYZVector &iniMom);
-   void AddHit(double ELoss, const XYZPoint &pos, const XYZVector &mom, double length);
+   void SimulateParticle(ModelPtr model, const XYZPoint &iniPos, const PxPyPzEVector &iniMom);
+   void AddHit(double ELoss, const XYZPoint &pos, const PxPyPzEVector &mom, double length);
    TGeoVolume *GetVolume(const XYZPoint &pos);
 };
 

--- a/AtDigitization/AtSimpleSimulation.h
+++ b/AtDigitization/AtSimpleSimulation.h
@@ -1,0 +1,57 @@
+#ifndef AT_SIMPLE_SIMULATION_H
+#define AT_SIMPLE_SIMULATION_H
+
+#include <Math/Point3D.h>
+#include <Math/Vector3D.h>
+#include <TClonesArray.h>
+
+#include <map>
+#include <memory>
+class AtELossModel;
+
+/**
+ * Class for simulating simple events using AtELossModels.
+ * Units in this class are MeV (energy), mm (distance) MeV/c (momentum).
+ */
+class AtSimpleSimulation {
+protected:
+   struct ParticleID {
+      int A;
+      int Z;
+
+      bool operator<(const ParticleID &other) const;
+   };
+   using ModelPtr = std::shared_ptr<AtELossModel>;
+   using XYZPoint = ROOT::Math::XYZPoint;
+   using XYZVector = ROOT::Math::XYZVector;
+
+   std::map<ParticleID, ModelPtr> fModels;
+   TClonesArray fMCPoints;
+
+   // Variables to across an entire event
+   int fTrackID;
+
+   double fDistStep{1.}; // Distance step in mm for particles
+
+public:
+   /**
+    * Assumes that the IO manager has been initialized (it will attempt to construct the branch needed here).
+    */
+   AtSimpleSimulation(bool isPersistant = true, std::string branchName = "AtTpcPoint");
+
+   ~AtSimpleSimulation() = default;
+
+   void AddModel(int Z, int A, ModelPtr model);
+
+   void NewEvent();
+   void SimulateParticle(int Z, int A, const XYZPoint &iniPos, const XYZVector &iniMom);
+
+protected:
+   bool IsInVolume(const std::string &volName, const XYZPoint &point);
+   std::string GetVolumeName(const XYZPoint &point);
+
+   void SimulateParticle(ModelPtr model, const XYZPoint &iniPos, const XYZVector &iniMom);
+   void AddHit(double ELoss, const XYZPoint &pos, const XYZVector &mom, double length);
+};
+
+#endif // AT_SIMPLE_SIMULATION_H

--- a/AtDigitization/AtTestSimulation.cxx
+++ b/AtDigitization/AtTestSimulation.cxx
@@ -18,8 +18,14 @@ void AtTestSimulation::Exec(Option_t *)
    fSimulation->NewEvent();
 
    XYZPoint pos(0, 0, 500);
-   XYZVector mom(0, 0, 1);
-
+   XYZVector momDir = XYZVector(0, 0, 1).Unit();
+   // Assume Pb208 (mass is 207.93 amu)
+   double m = 207.93 * 931.4936; // Mev
+   // Assume initial KE is 35 MeV/u
+   double E = m + 35 * 207.93;
+   // Grab the momentum
+   double p = sqrt(E * E - m * m);
+   PxPyPzEVector mom(0, 0, p, E);
    fSimulation->SimulateParticle(82, 208, pos, mom);
 }
 

--- a/AtDigitization/AtTestSimulation.cxx
+++ b/AtDigitization/AtTestSimulation.cxx
@@ -1,0 +1,26 @@
+#include "AtTestSimulation.h"
+
+#include <Math/Point3D.h>
+#include <Math/Vector3D.h>
+
+using namespace ROOT::Math;
+
+AtTestSimulation::AtTestSimulation() {}
+
+InitStatus AtTestSimulation::Init()
+{
+   fSimulation = std::make_unique<AtSimpleSimulation>();
+   return kSUCCESS;
+}
+
+void AtTestSimulation::Exec(Option_t *)
+{
+   fSimulation->NewEvent();
+
+   XYZPoint pos(0, 0, 500);
+   XYZVector mom(0, 0, 1);
+
+   fSimulation->SimulateParticle(82, 208, pos, mom);
+}
+
+ClassImp(AtTestSimulation);

--- a/AtDigitization/AtTestSimulation.cxx
+++ b/AtDigitization/AtTestSimulation.cxx
@@ -2,8 +2,16 @@
 
 #include "AtSimpleSimulation.h"
 
+#include <FairTask.h> // for InitStatus, kSUCCESS
+
 #include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h> // for Math, XYZPoint
 #include <Math/Vector3D.h>
+#include <Math/Vector3Dfwd.h> // for XYZVector
+#include <Math/Vector4D.h>    // for LorentzVector
+#include <Math/Vector4Dfwd.h> // for PxPyPzEVector
+
+#include <cmath>
 using namespace ROOT::Math;
 
 InitStatus AtTestSimulation::Init()
@@ -25,7 +33,7 @@ void AtTestSimulation::Exec(Option_t *)
    double E = m + 35 * 207.93;
    // Grab the momentum
    double p = sqrt(E * E - m * m);
-   PxPyPzEVector mom(0, 0, p, E);
+   PxPyPzEVector mom(momDir.X() * p, momDir.Y() * p, momDir.Z() * p, E);
    fSimulation->SimulateParticle(82, 208, pos, mom);
 }
 

--- a/AtDigitization/AtTestSimulation.cxx
+++ b/AtDigitization/AtTestSimulation.cxx
@@ -1,15 +1,15 @@
 #include "AtTestSimulation.h"
 
+#include "AtSimpleSimulation.h"
+
 #include <Math/Point3D.h>
 #include <Math/Vector3D.h>
-
 using namespace ROOT::Math;
-
-AtTestSimulation::AtTestSimulation() {}
 
 InitStatus AtTestSimulation::Init()
 {
-   fSimulation = std::make_unique<AtSimpleSimulation>();
+   fSimulation->Init();
+
    return kSUCCESS;
 }
 

--- a/AtDigitization/AtTestSimulation.h
+++ b/AtDigitization/AtTestSimulation.h
@@ -1,16 +1,16 @@
 #ifndef AtTestSimulation_h
 #define AtTestSimulation_h
 
-#include "AtSimpleSimulation.h"
-
 #include "FairTask.h"
+
+class AtSimpleSimulation;
 
 class AtTestSimulation : public FairTask {
 protected:
-   std::unique_ptr<AtSimpleSimulation> fSimulation{nullptr};
+   std::unique_ptr<AtSimpleSimulation> fSimulation{nullptr}; //!
 
 public:
-   AtTestSimulation();
+   AtTestSimulation(std::unique_ptr<AtSimpleSimulation> sim) : fSimulation(std::move(sim)) {}
    virtual ~AtTestSimulation() = default;
 
    virtual InitStatus Init() override;

--- a/AtDigitization/AtTestSimulation.h
+++ b/AtDigitization/AtTestSimulation.h
@@ -1,9 +1,17 @@
 #ifndef AtTestSimulation_h
 #define AtTestSimulation_h
 
+#include "AtSimpleSimulation.h" // for AtSimpleSimulation
+
+#include <Rtypes.h> // for THashConsistencyHolder, ClassDefOver...
+
 #include "FairTask.h"
 
-class AtSimpleSimulation;
+#include <memory>  // for unique_ptr
+#include <utility> // for move
+class TBuffer;
+class TClass;
+class TMemberInspector;
 
 class AtTestSimulation : public FairTask {
 protected:

--- a/AtDigitization/AtTestSimulation.h
+++ b/AtDigitization/AtTestSimulation.h
@@ -1,0 +1,24 @@
+#ifndef AtTestSimulation_h
+#define AtTestSimulation_h
+
+#include "AtSimpleSimulation.h"
+
+#include "FairTask.h"
+
+class AtTestSimulation : public FairTask {
+protected:
+   std::unique_ptr<AtSimpleSimulation> fSimulation{nullptr};
+
+public:
+   AtTestSimulation();
+   virtual ~AtTestSimulation() = default;
+
+   virtual InitStatus Init() override;
+   virtual void Exec(Option_t *option) override;
+   virtual void Finish() override {}
+   AtSimpleSimulation *GetSimulation() { return fSimulation.get(); }
+
+   ClassDefOverride(AtTestSimulation, 1);
+};
+
+#endif /* AtTestSimulation_h */

--- a/AtDigitization/CMakeLists.txt
+++ b/AtDigitization/CMakeLists.txt
@@ -27,6 +27,8 @@ AtSimulatedLine.cxx
 AtTrigger.cxx
 AtTriggerTask.cxx
 AtVectorResponse.cxx
+
+AtSimpleSimulation.cxx
 )
 
 generate_target_and_root_library(${LIBRARY_NAME}

--- a/AtDigitization/CMakeLists.txt
+++ b/AtDigitization/CMakeLists.txt
@@ -29,6 +29,7 @@ AtTriggerTask.cxx
 AtVectorResponse.cxx
 
 AtSimpleSimulation.cxx
+AtTestSimulation.cxx
 )
 
 generate_target_and_root_library(${LIBRARY_NAME}

--- a/AtSimulationData/AtMCPoint.cxx
+++ b/AtSimulationData/AtMCPoint.cxx
@@ -17,18 +17,14 @@
 using std::cout;
 using std::endl;
 
-// -----   Default constructor   -------------------------------------------
 AtMCPoint::AtMCPoint() : FairMCPoint() {}
-// -------------------------------------------------------------------------
 
-// -----   Standard constructor   ------------------------------------------
 AtMCPoint::AtMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t tof, Double_t length,
                      Double_t eLoss)
    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss)
 {
 }
 
-// -----   Standard constructor   ------------------------------------------
 AtMCPoint::AtMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t tof, Double_t length,
                      Double_t eLoss, TString VolName, Int_t detCopyID, Double_t EIni, Double_t AIni, Int_t A, Int_t Z)
    : FairMCPoint(trackID, detID, pos, mom, tof, length, eLoss), fDetCopyID(detCopyID), fVolName(std::move(VolName)),
@@ -76,4 +72,5 @@ void AtMCPoint::Clear(Option_t *)
    fAiso = 0;
    fZiso = 0;
 }
+
 ClassImp(AtMCPoint)

--- a/AtSimulationData/AtMCPoint.cxx
+++ b/AtSimulationData/AtMCPoint.cxx
@@ -36,6 +36,13 @@ AtMCPoint::AtMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Dou
 {
 }
 
+AtMCPoint::AtMCPoint(Int_t trackID, Int_t detID, XYZPoint pos, XYZVector mom, Double_t tof, Double_t length,
+                     Double_t eLoss)
+   : AtMCPoint(trackID, detID, TVector3(pos.X(), pos.Y(), pos.Z()), TVector3(mom.X(), mom.Y(), mom.Z()), 0, length,
+               eLoss)
+{
+}
+
 void AtMCPoint::Print(const Option_t *opt) const
 {
    cout << "-I- AtMCPoint: AtMC point for track " << fTrackID << " in detector " << fDetectorID << endl;
@@ -45,4 +52,28 @@ void AtMCPoint::Print(const Option_t *opt) const
         << endl;
 }
 
+void AtMCPoint::Clear(Option_t *)
+{
+   // Clear FairMCPoint
+   fTrackID = 0;
+   fEventId = 0;
+   fPx = 0;
+   fPy = 0;
+   fPz = 0;
+   fTime = 0;
+   fLength = 0;
+   fELoss = 0;
+   fDetectorID = 0;
+   fX = 0;
+   fY = 0;
+   fZ = 0;
+
+   // Clear AtMCPoint
+   fDetCopyID = 0;
+   fVolName = "";
+   fEnergyIni = 0;
+   fAngleIni = 0;
+   fAiso = 0;
+   fZiso = 0;
+}
 ClassImp(AtMCPoint)

--- a/AtSimulationData/AtMCPoint.h
+++ b/AtSimulationData/AtMCPoint.h
@@ -10,6 +10,8 @@
 
 #include <FairMCPoint.h>
 
+#include <Math/Point3D.h>
+#include <Math/Vector3D.h>
 #include <Rtypes.h>
 #include <TString.h>
 #include <TVector3.h>
@@ -17,10 +19,14 @@
 class TBuffer;
 class TClass;
 class TMemberInspector;
+class AtSimpleSimulation;
 
 class AtMCPoint : public FairMCPoint {
 
 protected:
+   using XYZPoint = ROOT::Math::XYZPoint;
+   using XYZVector = ROOT::Math::XYZVector;
+
    Int_t fDetCopyID = 0;
    TString fVolName;
    Double_t fEnergyIni = 0;
@@ -42,6 +48,7 @@ public:
     *@param eLoss    Energy deposit [GeV]
     **/
    AtMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t tof, Double_t length, Double_t eLoss);
+   AtMCPoint(Int_t trackID, Int_t detID, XYZPoint pos, XYZVector mom, Double_t tof, Double_t length, Double_t eLoss);
 
    AtMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t tof, Double_t length, Double_t eLoss,
              TString VolName, Int_t detCopyID, Double_t EIni, Double_t AIni, Int_t A, Int_t Z);
@@ -51,6 +58,8 @@ public:
    /** Copy constructor **/
    AtMCPoint(const AtMCPoint &point) = delete;
    AtMCPoint operator=(const AtMCPoint &point) = delete;
+
+   virtual void Clear(Option_t *) override;
 
    /** Accessors **/
    Int_t GetDetCopyID() const { return fDetCopyID; } // added by Marc
@@ -62,10 +71,17 @@ public:
 
    void SetDetCopyID(Int_t id) { fDetCopyID = id; };         // added by Marc
    void SetVolName(TString VolName) { fVolName = VolName; }; // added by Ari
+   void SetPosition(const XYZPoint &pos) { SetXYZ(pos.X(), pos.Y(), pos.Z()); }
+   void SetMomentum(const XYZVector &mom)
+   {
+      TVector3 mom2(mom.X(), mom.Y(), mom.Z());
+      FairMCPoint::SetMomentum(mom2);
+   }
 
    /** Output to screen **/
    virtual void Print(const Option_t *opt) const override;
 
+   friend AtSimpleSimulation;
    ClassDefOverride(AtMCPoint, 2)
 };
 

--- a/AtSimulationData/AtMCPoint.h
+++ b/AtSimulationData/AtMCPoint.h
@@ -11,7 +11,9 @@
 #include <FairMCPoint.h>
 
 #include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h> // for XYZPoint
 #include <Math/Vector3D.h>
+#include <Math/Vector3Dfwd.h> // for XYZVector
 #include <Rtypes.h>
 #include <TString.h>
 #include <TVector3.h>

--- a/macro/e12014/adam/simulation/run_eve_simple.C
+++ b/macro/e12014/adam/simulation/run_eve_simple.C
@@ -1,0 +1,49 @@
+/*#include "TString.h"
+#include "AtEventDrawTask.h"
+#include "AtEventManager.h"
+
+#include "FairLogger.h"
+#include "FairParRootFileIo.h"
+#include "FairRunAna.h"
+*/
+
+void run_eve_simple(TString OutputDataFile = "./data/output.sim_display.root")
+{
+   TString InputDataFile = "./data/output_digi.root";
+   std::cout << "Opening: " << InputDataFile << std::endl;
+
+   TString dir = getenv("VMCWORKDIR");
+   TString geoFile = "ATTPC_v1.1_geomanager.root";
+   TString mapFile = "e12014_pad_mapping.xml";
+
+   TString InputDataPath = InputDataFile;
+   TString OutputDataPath = OutputDataFile;
+   TString GeoDataPath = dir + "/geometry/" + geoFile;
+   TString mapDir = dir + "/scripts/" + mapFile;
+
+   FairRunAna *fRun = new FairRunAna();
+   FairRootFileSink *sink = new FairRootFileSink(OutputDataFile);
+   FairFileSource *source = new FairFileSource(InputDataFile);
+   fRun->SetSource(source);
+   fRun->SetSink(sink);
+   fRun->SetGeomFile(GeoDataPath);
+
+   FairRuntimeDb *rtdb = fRun->GetRuntimeDb();
+   FairParRootFileIo *parIo1 = new FairParRootFileIo();
+   // parIo1->open("param.dummy.root");
+   rtdb->setFirstInput(parIo1);
+
+   AtEventDrawTask *eve = new AtEventDrawTask();
+   auto fMap = std::make_shared<AtTpcMap>();
+   fMap->ParseXMLMap(mapDir.Data());
+   AtViewerManager *eveMan = new AtViewerManager(fMap);
+
+   auto tabMain = std::make_unique<AtTabMain>();
+   tabMain->SetMultiHit(100); // Set the maximum number of multihits in the visualization
+   eveMan->AddTab(std::move(tabMain));
+
+   eveMan->Init();
+
+   std::cout << "Finished init" << std::endl;
+   // eveMan->RunEvent(27);
+}

--- a/macro/e12014/adam/simulation/simpleSim.C
+++ b/macro/e12014/adam/simulation/simpleSim.C
@@ -1,0 +1,86 @@
+void simpleSim()
+{
+   TString inOutDir = "./data/";
+   TString outputFile = inOutDir + "output_digi.root";
+   TString scriptfile = "e12014_pad_mapping.xml";
+   TString paramFile = "ATTPC.e12014.par";
+
+   TString dir = getenv("VMCWORKDIR");
+
+   // Create the full parameter file paths
+   TString digiParFile = dir + "/parameters/" + paramFile;
+   TString mapParFile = dir + "/scripts/" + scriptfile;
+
+   // -----   Timer   --------------------------------------------------------
+   TStopwatch timer;
+
+   // ------------------------------------------------------------------------
+
+   // __ Run ____________________________________________
+   FairRunAna *fRun = new FairRunAna();
+   fRun->SetOutputFile(outputFile);
+
+   FairRuntimeDb *rtdb = fRun->GetRuntimeDb();
+   FairParAsciiFileIo *parIo1 = new FairParAsciiFileIo();
+   parIo1->open(digiParFile.Data(), "in");
+   rtdb->setFirstInput(parIo1);
+
+   // Create the detector map to pass to the simulation
+   auto mapping = std::make_shared<AtTpcMap>();
+   mapping->ParseXMLMap(mapParFile.Data());
+   mapping->GeneratePadPlane();
+   // mapping->ParseInhibitMap("./data/inhibit.txt", AtMap::InhibitType::kTotal);
+
+   AtTestSimulation *sim = new AtTestSimulation();
+
+   AtClusterizeLineTask *clusterizer = new AtClusterizeLineTask();
+   clusterizer->SetPersistence(kFALSE);
+
+   // AtPulseTask *pulse = new AtPulseTask();
+   AtPulseLineTask *pulse = new AtPulseLineTask();
+   pulse->SetPersistence(kTRUE);
+   pulse->SetMap(mapping);
+   pulse->SetSaveMCInfo();
+
+   auto psa = std::make_unique<AtPSAMax>();
+   psa->SetThreshold(0);
+
+   // Create PSA task
+   AtPSAtask *psaTask = new AtPSAtask(std::move(psa));
+   psaTask->SetPersistence(kTRUE);
+
+   AtRansacTask *ransacTask = new AtRansacTask();
+   ransacTask->SetPersistence(kTRUE);
+   ransacTask->SetVerbose(kFALSE);
+   ransacTask->SetDistanceThreshold(20.0);
+   ransacTask->SetMinHitsLine(10);
+
+   fRun->AddTask(sim);
+   fRun->AddTask(clusterizer);
+   fRun->AddTask(pulse);
+   fRun->AddTask(psaTask);
+
+   //  __ Init and run ___________________________________
+   fRun->Init();
+
+   // Add energy loss models
+   auto eloss = std::make_shared<AtTools::AtELossTable>();
+   eloss->LoadSrimTable("./../PbinHeFull.txt");
+   sim->GetSimulation()->AddModel(82, 208, eloss);
+
+   timer.Start();
+   // fRun->Run(0, 20001);
+   fRun->Run(0, 10);
+   timer.Stop();
+
+   std::cout << std::endl << std::endl;
+   std::cout << "Macro finished succesfully." << std::endl << std::endl;
+   // -----   Finish   -------------------------------------------------------
+
+   Double_t rtime = timer.RealTime();
+   Double_t ctime = timer.CpuTime();
+   cout << endl;
+   cout << "Real time " << rtime << " s, CPU time " << ctime << " s" << endl;
+   cout << endl;
+   // ------------------------------------------------------------------------
+}


### PR DESCRIPTION
Also allows for the sim and digi to happen in the same macro.

This is work moving towards developing a MC-fit like track reconstruction algorithm where energy loss models are more unknown then the lower energy/masses typically used by the AT-TPC.