### PR TITLE
Add base class for all event types. REQUIRES REGENERATING DATA

### DIFF
--- a/AtData/AtBaseEvent.cxx
+++ b/AtData/AtBaseEvent.cxx
@@ -1,0 +1,50 @@
+#include "AtBaseEvent.h"
+
+#include <FairLogger.h>
+
+AtBaseEvent::AtBaseEvent(std::string name) : TNamed(name.c_str(), "") {}
+
+AtBaseEvent &AtBaseEvent::operator=(AtBaseEvent object)
+{
+   swap(*this, object);
+   return *this;
+}
+
+void AtBaseEvent::Clear(Option_t *opt)
+{
+   TNamed::Clear(opt);
+
+   fEventID = -1;
+   fAuxPadMap.clear();
+   std::fill(fTimestamp.begin(), fTimestamp.end(), 0);
+
+   fIsGood = true;
+   fIsInGate = false;
+}
+
+const AtAuxPad *AtBaseEvent::GetAuxPad(std::string auxName) const
+{
+   auto padIt = fAuxPadMap.find(auxName);
+   if (padIt == fAuxPadMap.end())
+      return nullptr;
+   else
+      return &(padIt->second);
+}
+
+void AtBaseEvent::SetTimestamp(ULong64_t timestamp, int index)
+{
+   if (index < fTimestamp.size())
+      fTimestamp[index] = timestamp;
+   else
+      LOG(error) << "Failed to add timestamp with index " << index << " to raw event. Max number of timestamps is "
+                 << fTimestamp.size();
+}
+
+std::pair<AtAuxPad *, bool> AtBaseEvent::AddAuxPad(std::string auxName)
+{
+   auto ret = fAuxPadMap.emplace(auxName, AtAuxPad(auxName));
+   auto pad = &(ret.first->second);
+   return {pad, ret.second};
+}
+
+ClassImp(AtBaseEvent);

--- a/AtData/AtBaseEvent.h
+++ b/AtData/AtBaseEvent.h
@@ -1,0 +1,80 @@
+#ifndef ATBASEEVENT_H
+#define ATBASEEVENT_H
+#include "AtAuxPad.h"
+
+#include <Rtypes.h>
+#include <TNamed.h>
+
+#include <algorithm> // for max
+#include <map>       // for swap, map
+#include <string>    // for string, allocator
+#include <utility>   // for swap, move, pair
+#include <vector>    // for vector, swap
+class TBuffer;
+class TClass;
+class TMemberInspector;
+
+/**
+ * @brief Base class for all event types in ATTPCROOT
+ */
+class AtBaseEvent : public TNamed {
+
+protected:
+   using AuxPadMap = std::map<std::string, AtAuxPad>;
+   ULong_t fEventID = -1;
+   Bool_t fIsGood = true;
+   Bool_t fIsInGate = false;
+
+   std::vector<ULong64_t> fTimestamp{1};
+   AuxPadMap fAuxPadMap;
+
+public:
+   AtBaseEvent(std::string name = "AtBaseEvent");
+   virtual ~AtBaseEvent() = default;
+   AtBaseEvent(AtBaseEvent &&) = default;
+   AtBaseEvent(const AtBaseEvent &) = default;
+   AtBaseEvent &operator=(AtBaseEvent object);
+
+   friend void swap(AtBaseEvent &first, AtBaseEvent &second)
+   {
+      using std::swap;
+      swap(first.fEventID, second.fEventID);
+      swap(first.fIsGood, second.fIsGood);
+      swap(first.fIsInGate, second.fIsInGate);
+      swap(first.fTimestamp, second.fTimestamp);
+      swap(first.fAuxPadMap, second.fAuxPadMap);
+   };
+
+   void Clear(Option_t *opt) override;
+
+   /**
+    * @brief Add new auxilary pad (AtAuxPad) to event
+    * @param Name of new auxiliary pad
+    * @return Returns a pointer to the newly added pad, or existing pad if auxName is already used,
+    * bool returned is true if insert occurred.
+    */
+   std::pair<AtAuxPad *, bool> AddAuxPad(std::string auxName);
+
+   void SetEventID(ULong_t evtid) { fEventID = evtid; }
+   void SetIsGood(Bool_t value) { fIsGood = value; }
+   void SetTimestamp(ULong64_t timestamp, int index = 0);
+   void SetNumberOfTimestamps(int numTS) { fTimestamp.resize(numTS, 0); }
+   void SetIsExtGate(Bool_t value) { fIsInGate = value; }
+
+   ULong_t GetEventID() const { return fEventID; }
+   ULong64_t GetTimestamp(int index = 0) const { return index < fTimestamp.size() ? fTimestamp.at(index) : 0; }
+   const std::vector<ULong64_t> &GetTimestamps() const { return fTimestamp; }
+   Bool_t IsGood() const { return fIsGood; }
+   Bool_t GetIsExtGate() const { return fIsInGate; }
+
+   AtAuxPad *GetAuxPad(std::string auxPad)
+   {
+      return const_cast<AtAuxPad *>(const_cast<const AtBaseEvent *>(this)->GetAuxPad(std::move(auxPad)));
+   }
+   const AtAuxPad *GetAuxPad(std::string auxPad) const;
+   const AuxPadMap &GetAuxPads() const { return fAuxPadMap; }
+
+   ClassDefOverride(AtBaseEvent, 1)
+};
+
+#endif //#ifndef ATBASEEVENT_H

--- a/AtData/AtDataLinkDef.h
+++ b/AtData/AtDataLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link C++ class AtPadValue + ;
 #pragma link C++ class AtPulserInfo + ;
 
+#pragma link C++ class AtBaseEvent + ;
 #pragma link C++ class AtRawEvent + ;
 #pragma link C++ class AtHit + ;
 #pragma link C++ class AtHitCluster + ;

--- a/AtData/AtEvent.cxx
+++ b/AtData/AtEvent.cxx
@@ -7,57 +7,41 @@
 
 #include <algorithm>
 #include <iostream>
+#include <string> // for string
 
 ClassImp(AtEvent);
 
-AtEvent::AtEvent() : AtEvent(-1, false) {}
-
-AtEvent::AtEvent(Int_t eventID, Bool_t isGood, Bool_t isInGate, ULong_t timestamp)
-   : TNamed("AtEvent", "Event container"), fEventID(eventID), fIsGood(isGood), fIsInGate(isInGate),
-     fTimestamp(timestamp)
-{
-}
+AtEvent::AtEvent() : AtBaseEvent("AtEvent") {}
 
 AtEvent::AtEvent(const AtEvent &copy)
-   : fEventID(copy.fEventID), fIsGood(copy.fIsGood), fIsInGate(copy.fIsInGate), fTimestamp(copy.fTimestamp),
-     fEventCharge(copy.fEventCharge), fRhoVariance(copy.fRhoVariance), fAuxPadArray(copy.fAuxPadArray),
+   : AtBaseEvent(copy), fEventCharge(copy.fEventCharge), fRhoVariance(copy.fRhoVariance),
      fMultiplicityMap(copy.fMultiplicityMap), fMeshSig(copy.fMeshSig)
 {
    for (const auto &hit : copy.fHitArray)
       fHitArray.push_back(hit->Clone());
 }
 
-AtEvent::AtEvent(const AtRawEvent &copy)
-   : AtEvent(copy.GetEventID(), copy.IsGood(), copy.GetIsExtGate(), copy.GetTimestamp())
+// Here we are intentionally slicing to call the copy constructor to copy all the shared data between
+// event types
+AtEvent::AtEvent(const AtRawEvent &copy) : AtBaseEvent(copy) // NOLINT
 {
-   for (const auto &[auxName, auxPad] : copy.GetAuxPads())
-      fAuxPadArray.emplace_back(auxPad);
-}
-void AtEvent::Clear(Option_t *opt)
-{
-   fEventID = -1;
-   fIsGood = false;
-   fIsInGate = false;
-   fEventCharge = -100;
-   fRhoVariance = 0;
-   fTimestamp = 0;
-   fHitArray.clear();
-   fAuxPadArray.clear();
-   fMultiplicityMap.clear();
-   fMeshSig.fill(0);
+   SetName("AtEvent");
 }
 
-void AtEvent::CopyFrom(const AtEvent &inputEvent)
+AtEvent &AtEvent::operator=(AtEvent object)
 {
-   this->fEventID = inputEvent.GetEventID();
-   this->fIsGood = inputEvent.fIsGood;
-   this->fIsInGate = inputEvent.fIsInGate;
-   this->fEventCharge = inputEvent.fEventCharge;
-   this->fRhoVariance = inputEvent.fRhoVariance;
-   this->fTimestamp = inputEvent.fTimestamp;
-   this->fAuxPadArray = inputEvent.fAuxPadArray;
-   this->fMultiplicityMap = inputEvent.fMultiplicityMap;
-   this->fMeshSig = inputEvent.fMeshSig;
+   swap(*this, object);
+   return *this;
+}
+
+void AtEvent::Clear(Option_t *opt)
+{
+   AtBaseEvent::Clear(opt);
+   fEventCharge = -100;
+   fRhoVariance = 0;
+   fHitArray.clear();
+   fMultiplicityMap.clear();
+   fMeshSig.fill(0);
 }
 
 void AtEvent::SetMeshSignal(Int_t idx, Float_t val)

--- a/AtData/AtHit.h
+++ b/AtData/AtHit.h
@@ -89,6 +89,16 @@ public:
    const std::vector<AtHit::MCSimPoint> &GetMCSimPointArray() const { return fMCSimPointArray; }
 
    static Bool_t SortHit(const AtHit &lhs, const AtHit &rhs) { return lhs.GetPadNum() < rhs.GetPadNum(); }
+   static Bool_t SortHit(const std::unique_ptr<AtHit> &lhs, const std::unique_ptr<AtHit> &rhs)
+   {
+      return SortHit(*lhs, *rhs);
+   }
+
+   static Bool_t SortHitTimePtr(const std::unique_ptr<AtHit> &lhs, const std::unique_ptr<AtHit> &rhs)
+   {
+      return SortHitTime(*lhs, *rhs);
+   }
+
    static Bool_t SortHitTime(const AtHit &lhs, const AtHit &rhs) { return lhs.GetTimeStamp() < rhs.GetTimeStamp(); }
 
    struct MCSimPoint {

--- a/AtData/AtPadArray.cxx
+++ b/AtData/AtPadArray.cxx
@@ -1,6 +1,6 @@
 #include "AtPadArray.h"
 
-#include <TH1D.h>
+#include <TH1.h> // for TH1D
 
 std::unique_ptr<AtPadBase> AtPadArray::Clone() const
 {

--- a/AtData/AtPadArray.h
+++ b/AtData/AtPadArray.h
@@ -5,8 +5,9 @@
 
 #include <Rtypes.h> // for Double_t, ClassDefOverride
 
-#include <array>   // for array
-#include <memory>  // for unique_ptr
+#include <array>  // for array
+#include <memory> // for unique_ptr
+#include <string>
 #include <utility> // for move
 
 class TBuffer;

--- a/AtData/AtPatternEvent.cxx
+++ b/AtData/AtPatternEvent.cxx
@@ -1,18 +1,30 @@
 #include "AtPatternEvent.h"
 
+#include "AtHit.h" // for AtHit
+
 #include <Rtypes.h>
+
+#include <string> // for string
 
 ClassImp(AtPatternEvent);
 
-AtPatternEvent::AtPatternEvent() : TNamed("AtPatternEvent", "Pattern Recognition Event") {}
+AtPatternEvent::AtPatternEvent() : AtBaseEvent("AtPatternEvent") {}
 
-AtPatternEvent::~AtPatternEvent() = default;
-
-void AtPatternEvent::SetTrackCand(std::vector<AtTrack> tracks)
+AtPatternEvent::AtPatternEvent(const AtPatternEvent &copy) : AtBaseEvent(copy), fTrackCand(copy.fTrackCand)
 {
-   fTrackCand = tracks;
+   for (const auto &hit : copy.fNoise)
+      fNoise.push_back(hit->Clone());
 }
-std::vector<AtTrack> &AtPatternEvent::GetTrackCand()
+
+AtPatternEvent &AtPatternEvent::operator=(AtPatternEvent object)
 {
-   return fTrackCand;
+   swap(*this, object);
+   return *this;
+}
+
+void AtPatternEvent::Clear(Option_t *opt)
+{
+   AtBaseEvent::Clear(opt);
+   fTrackCand.clear();
+   fNoise.clear();
 }

--- a/AtData/AtPatternEvent.h
+++ b/AtData/AtPatternEvent.h
@@ -1,38 +1,59 @@
 #ifndef ATPATTERNEVENT_H
 #define ATPATTERNEVENT_H
 
-#include "AtHit.h"
+#include "AtBaseEvent.h"
 #include "AtTrack.h"
 
 #include <Rtypes.h>
-#include <TNamed.h>
 
 #include <algorithm>
+#include <memory> // for make_unique, unique_ptr
 #include <utility>
 #include <vector>
 
+class AtHit;
 class TBuffer;
 class TClass;
 class TMemberInspector;
 
-class AtPatternEvent : public TNamed {
+class AtPatternEvent : public AtBaseEvent {
 private:
+   using HitPtr = std::unique_ptr<AtHit>;
+   using HitVector = std::vector<HitPtr>;
+
    std::vector<AtTrack> fTrackCand; // Candidate tracks
-   std::vector<AtHit> fNoise;
+   HitVector fNoise;
 
 public:
    AtPatternEvent();
-   ~AtPatternEvent();
+   AtPatternEvent(const AtPatternEvent &copy);
+   AtPatternEvent(AtPatternEvent &&copy) = default;
+   AtPatternEvent &operator=(const AtPatternEvent object);
+   virtual ~AtPatternEvent() = default;
 
-   void SetTrackCand(std::vector<AtTrack> tracks);
+   void Clear(Option_t *opt = nullptr) override;
+
+   friend void swap(AtPatternEvent &first, AtPatternEvent &second)
+   {
+      using std::swap;
+      swap(dynamic_cast<AtBaseEvent &>(first), dynamic_cast<AtBaseEvent &>(second));
+      swap(first.fTrackCand, second.fTrackCand);
+      swap(first.fNoise, second.fNoise);
+   };
+
+   void SetTrackCand(std::vector<AtTrack> tracks) { fTrackCand = std::move(tracks); }
    void AddTrack(const AtTrack &track) { fTrackCand.push_back(track); }
    void AddTrack(AtTrack &&track) { fTrackCand.push_back(track); }
 
-   void AddNoise(AtHit hit) { fNoise.push_back(std::move(hit)); }
-   const std::vector<AtHit> &GetNoiseHits() { return fNoise; }
-   std::vector<AtTrack> &GetTrackCand();
+   template <typename... Ts>
+   void AddNoise(Ts &&...params)
+   {
+      fNoise.emplace_back(std::make_unique<AtHit>(std::forward<Ts>(params)...));
+   }
+   const HitVector &GetNoiseHits() { return fNoise; }
+   std::vector<AtTrack> &GetTrackCand() { return fTrackCand; }
 
-   ClassDef(AtPatternEvent, 2);
+   ClassDefOverride(AtPatternEvent, 3);
 };
 
 #endif

--- a/AtData/AtRawEvent.cxx
+++ b/AtData/AtRawEvent.cxx
@@ -11,18 +11,10 @@
 #include "AtPad.h"
 #include "AtPadReference.h" // for AtPadReference (ptr only), operator==
 
-#include <FairLogger.h>
-
 ClassImp(AtRawEvent);
 
-AtRawEvent::AtRawEvent() : TNamed("AtRawEvent", "Raw event container")
-{
-   SetNumberOfTimestamps(1);
-}
-
 AtRawEvent::AtRawEvent(const AtRawEvent &obj)
-   : fEventID(obj.fEventID), fAuxPadMap(obj.fAuxPadMap), fFpnMap(obj.fFpnMap), fTimestamp(obj.fTimestamp),
-     fIsInGate(obj.fIsInGate), fSimMCPointMap(obj.fSimMCPointMap), fIsGood(obj.fIsGood)
+   : AtBaseEvent(obj), fFpnMap(obj.fFpnMap), fSimMCPointMap(obj.fSimMCPointMap)
 {
    for (const auto &pad : obj.fPadList)
       fPadList.push_back(pad->ClonePad());
@@ -34,6 +26,7 @@ AtRawEvent &AtRawEvent::operator=(AtRawEvent object)
    return *this;
 }
 
+/*
 void AtRawEvent::CopyAllButData(const AtRawEvent *event)
 {
    fEventID = event->fEventID;
@@ -41,34 +34,15 @@ void AtRawEvent::CopyAllButData(const AtRawEvent *event)
    fIsGood = event->fIsGood;
    fIsInGate = event->fIsInGate;
 }
+*/
 
 void AtRawEvent::Clear(Option_t *opt)
 {
-   fEventID = -1;
+   AtBaseEvent::Clear(opt);
+
    fPadList.clear();
-   fAuxPadMap.clear();
    fFpnMap.clear();
-   fTimestamp.clear();
    fSimMCPointMap.clear();
-
-   fIsGood = true;
-   fIsInGate = false;
-}
-
-std::pair<AtAuxPad *, bool> AtRawEvent::AddAuxPad(std::string auxName)
-{
-   auto ret = fAuxPadMap.emplace(auxName, AtAuxPad(auxName));
-   auto pad = &(ret.first->second);
-   return {pad, ret.second};
-}
-
-void AtRawEvent::SetTimestamp(ULong64_t timestamp, int index)
-{
-   if (index < fTimestamp.size())
-      fTimestamp[index] = timestamp;
-   else
-      LOG(error) << "Failed to add timestamp with index " << index << " to raw event. Max number of timestamps is "
-                 << fTimestamp.size();
 }
 
 void AtRawEvent::RemovePad(Int_t padNum)
@@ -90,15 +64,6 @@ const AtPad *AtRawEvent::GetFpn(const AtPadReference &ref) const
 {
    auto padIt = fFpnMap.find(ref);
    if (padIt == fFpnMap.end())
-      return nullptr;
-   else
-      return &(padIt->second);
-}
-
-const AtAuxPad *AtRawEvent::GetAuxPad(std::string auxName) const
-{
-   auto padIt = fAuxPadMap.find(auxName);
-   if (padIt == fAuxPadMap.end())
       return nullptr;
    else
       return &(padIt->second);

--- a/AtData/AtRawEvent.h
+++ b/AtData/AtRawEvent.h
@@ -10,11 +10,10 @@
 #ifndef AtRAWEVENT_H
 #define AtRAWEVENT_H
 
-#include "AtAuxPad.h"
+#include "AtBaseEvent.h"
 #include "AtPadReference.h" // IWYU pragma: keep
 
 #include <Rtypes.h>
-#include <TNamed.h>
 
 #include <cstddef>
 #include <functional> // for hash
@@ -30,22 +29,14 @@ class TBuffer;
 class TClass;
 class TMemberInspector;
 
-class AtRawEvent : public TNamed {
+class AtRawEvent : public AtBaseEvent {
 private:
-   using AuxPadMap = std::map<std::string, AtAuxPad>;
-   using FpnMap = std::unordered_map<AtPadReference, AtPad>;
    using AtPadPtr = std::unique_ptr<AtPad>;
+   using FpnMap = std::unordered_map<AtPadReference, AtPad>;
    using PadVector = std::vector<AtPadPtr>;
 
-   ULong_t fEventID = -1;
    PadVector fPadList;
-   AuxPadMap fAuxPadMap;
    FpnMap fFpnMap;
-
-   std::vector<ULong64_t> fTimestamp;
-
-   Bool_t fIsGood = true;
-   Bool_t fIsInGate = false;
 
    std::multimap<Int_t, std::size_t> fSimMCPointMap; //<! Monte Carlo Point - Hit map for kinematics
 
@@ -53,7 +44,7 @@ private:
    friend class AtFilterFFT;
 
 public:
-   AtRawEvent();
+   AtRawEvent() : AtBaseEvent("AtRawEvent"){};
    AtRawEvent(AtRawEvent &&obj) = default;
    AtRawEvent(const AtRawEvent &object);
    AtRawEvent &operator=(AtRawEvent object);
@@ -62,19 +53,14 @@ public:
    friend void swap(AtRawEvent &first, AtRawEvent &second)
    {
       using std::swap;
-
-      swap(first.fEventID, second.fEventID);
+      swap(dynamic_cast<AtBaseEvent &>(first), dynamic_cast<AtBaseEvent &>(second));
       swap(first.fPadList, second.fPadList);
-      swap(first.fAuxPadMap, second.fAuxPadMap);
       swap(first.fFpnMap, second.fFpnMap);
-      swap(first.fTimestamp, second.fTimestamp);
-      swap(first.fIsGood, second.fIsGood);
-      swap(first.fIsInGate, second.fIsInGate);
       swap(first.fSimMCPointMap, second.fSimMCPointMap);
    };
 
    /// Copy everything but the data (pads, aux pads, and MCPointMap) to this event
-   void CopyAllButData(const AtRawEvent *event);
+   // void CopyAllButData(const AtRawEvent *event);
 
    void Clear(Option_t *opt = nullptr) override;
 
@@ -107,35 +93,15 @@ public:
       fPadList.push_back(std::move(ptr));
       return fPadList.back().get();
    }
-   /**
-    * @brief Add new auxilary pad (AtAuxPad) to event
-    * @param Name of new auxiliary pad
-    * @return Returns a pointer to the newly added pad, or existing pad if auxName is already used,
-    * bool returned is true if insert occurred.
-    */
-   std::pair<AtAuxPad *, bool> AddAuxPad(std::string auxName);
 
    AtPad *AddFPN(const AtPadReference &ref);
 
    void RemovePad(Int_t padNum);
    void SetSimMCPointMap(std::multimap<Int_t, std::size_t> map) { fSimMCPointMap = std::move(map); }
 
-   // setters
-   void SetEventID(ULong_t evtid) { fEventID = evtid; }
-   void SetIsGood(Bool_t value) { fIsGood = value; }
-   void SetTimestamp(ULong64_t timestamp, int index = 0);
-   void SetNumberOfTimestamps(int numTS) { fTimestamp.resize(numTS, 0); }
-   void SetIsExtGate(Bool_t value) { fIsInGate = value; }
-
    // getters
-   ULong_t GetEventID() const { return fEventID; }
    Int_t GetNumPads() const { return fPadList.size(); }
    Int_t GetNumAuxPads() const { return fAuxPadMap.size(); }
-   ULong64_t GetTimestamp(int index = 0) const { return index < fTimestamp.size() ? fTimestamp.at(index) : 0; }
-   const std::vector<ULong64_t> &GetTimestamps() const { return fTimestamp; }
-   Bool_t IsGood() const { return fIsGood; }
-   Bool_t GetIsExtGate() const { return fIsInGate; }
-
    AtPad *GetPad(Int_t padNum) { return const_cast<AtPad *>(const_cast<const AtRawEvent *>(this)->GetPad(padNum)); }
    const AtPad *GetPad(Int_t padNum) const;
    AtPad *GetFpn(const AtPadReference &ref)
@@ -143,19 +109,13 @@ public:
       return const_cast<AtPad *>(const_cast<const AtRawEvent *>(this)->GetFpn(ref));
    }
    const AtPad *GetFpn(const AtPadReference &ref) const;
-   AtAuxPad *GetAuxPad(std::string auxPad)
-   {
-      return const_cast<AtAuxPad *>(const_cast<const AtRawEvent *>(this)->GetAuxPad(std::move(auxPad)));
-   }
-   const AtAuxPad *GetAuxPad(std::string auxPad) const;
    const PadVector &GetPads() const { return fPadList; }
    PadVector &GetPads() { return const_cast<PadVector &>(const_cast<const AtRawEvent *>(this)->GetPads()); }
 
-   const AuxPadMap &GetAuxPads() const { return fAuxPadMap; }
    const FpnMap &GetFpnPads() const { return fFpnMap; }
    std::multimap<Int_t, std::size_t> &GetSimMCPointMap() { return fSimMCPointMap; }
 
-   ClassDefOverride(AtRawEvent, 6);
+   ClassDefOverride(AtRawEvent, 7);
 };
 
 #endif

--- a/AtData/CMakeLists.txt
+++ b/AtData/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
   AtPulserInfo.cxx
   AtPadReference.cxx
   
+  AtBaseEvent.cxx
   AtRawEvent.cxx
   AtHit.cxx
   AtHitCluster.cxx

--- a/AtEventDisplay/AtTabs/AtTabEnergyLoss.h
+++ b/AtEventDisplay/AtTabs/AtTabEnergyLoss.h
@@ -37,6 +37,7 @@ protected:
    using XYZVector = ROOT::Math::XYZVector;
    using XYZPoint = ROOT::Math::XYZPoint;
    using TH1Ptr = std::unique_ptr<TH1F>;
+   using HitVector = std::vector<std::unique_ptr<AtHit>>;
 
    AtTabInfoFairRoot<AtRawEvent> fRawEvent;         //< Points to selected RawEventBranch
    AtTabInfoFairRoot<AtEvent> fEvent;               //< Points to selected EventBranch
@@ -105,7 +106,7 @@ private:
 
    void FillSums(float threshold = 15);
 
-   void FillChargeSum(TH1F *hist, const std::vector<AtHit> &hits, int threshold);
+   void FillChargeSum(TH1F *hist, const HitVector &hits, int threshold);
    void FillFitSum(TH1F *hist, const AtHit &hit, int threshold);
 
    void FillRatio();

--- a/AtEventDisplay/AtTabs/AtTabMain.cxx
+++ b/AtEventDisplay/AtTabs/AtTabMain.cxx
@@ -302,14 +302,14 @@ void AtTabMain::SetPointsFromHits(TEvePointSet &hitSet, const std::vector<std::u
 
 void AtTabMain::SetPointsFromTrack(TEvePointSet &hitSet, const AtTrack &track)
 {
-   Int_t nHits = track.GetHitArrayConst().size();
+   Int_t nHits = track.GetHitArray().size();
 
    hitSet.Reset(nHits);
    hitSet.SetOwnIds(true);
 
    for (Int_t i = 0; i < nHits; i++) {
 
-      auto &hit = track.GetHitArrayConst()[i];
+      auto &hit = *track.GetHitArray()[i];
 
       if (hit.GetCharge() < fThreshold)
          continue;

--- a/AtEventDisplay/Deprecated/AtEventDrawTask.cxx
+++ b/AtEventDisplay/Deprecated/AtEventDrawTask.cxx
@@ -7,6 +7,7 @@
 #include "AtEventDrawTask.h"
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include "AtAuxPad.h"       // for AtAuxPad
+#include "AtBaseEvent.h"    // for AtBaseEvent::AuxPadMap
 #include "AtEvent.h"        // for AtEvent, hitVector
 #include "AtEventManager.h" // for AtEventManager
 #include "AtFindVertex.h"   //for vertex
@@ -338,7 +339,7 @@ void AtEventDrawTask::DrawRecoHits()
          fHitLine.back()->SetElementName(Form("line_%i", (int)fHitLine.size() - 1));
       }
 
-      std::vector<AtHit> trackHits = track.GetHitArray();
+      std::vector<AtHit> trackHits = track.GetHitArrayObject();
 
       /*      fHitSetTFHC.push_back(
                std::make_unique<TEvePointSet>(Form("HitMC_%d", i), 0, TEvePointSelectorConsumer::kTVT_XYZ));
@@ -388,7 +389,7 @@ void AtEventDrawTask::DrawRecoHits()
    fHitSetTFHC.back()->SetMarkerStyle(fHitStyle);
 
    for (auto &hit : patternEvent->GetNoiseHits()) {
-      auto position = hit.GetPosition();
+      auto position = hit->GetPosition();
       fHitSetTFHC.back()->SetNextPoint(position.X() / 10., position.Y() / 10., position.Z() / 10.);
    }
 

--- a/AtEventDisplay/Deprecated/AtEventDrawTaskProto.cxx
+++ b/AtEventDisplay/Deprecated/AtEventDrawTaskProto.cxx
@@ -1,6 +1,7 @@
 #include "AtEventDrawTaskProto.h"
 // IWYU pragma: no_include <ext/alloc_traits.h>
 #include "AtAuxPad.h"            // for AtAuxPad
+#include "AtBaseEvent.h"         // for AtBaseEvent::AuxPadMap
 #include "AtEvent.h"             // for AtEvent, hitVector
 #include "AtEventManagerProto.h" // for AtEventManagerProto
 #include "AtHit.h"               // for AtHit
@@ -472,7 +473,7 @@ void AtEventDrawTaskProto::DrawHitPoints()
                for (Int_t i = 0; i < TrackCand.size(); i++) {
 
                   AtTrack track = TrackCand.at(i);
-                  std::vector<AtHit> trackHits = track.GetHitArray();
+                  std::vector<AtHit> trackHits = track.GetHitArrayObject();
                   int nHitsMin = trackHits.size();
 
                   fHitSetPR[i] = new TEvePointSet(Form("HitPR_%d", i), nHitsMin, TEvePointSelectorConsumer::kTVT_XYZ);

--- a/AtEventDisplay/Deprecated/AtEventDrawTaskS800.cxx
+++ b/AtEventDisplay/Deprecated/AtEventDrawTaskS800.cxx
@@ -485,7 +485,7 @@ void AtEventDrawTaskS800::DrawHitPoints()
             for (Int_t i = 0; i < TrackCand.size(); i++) {
 
                AtTrack track = TrackCand.at(i);
-               std::vector<AtHit> trackHits = track.GetHitArray();
+               std::vector<AtHit> trackHits = track.GetHitArrayObject();
 
                fHitSetTFHC[i] = new TEvePointSet(Form("HitMC_%d", i), nHitsMin, TEvePointSelectorConsumer::kTVT_XYZ);
                fHitSetTFHC[i]->SetMarkerColor(GetTrackColor(i) + 1);

--- a/AtEventDisplay/Deprecated/AtEventManager.cxx
+++ b/AtEventDisplay/Deprecated/AtEventManager.cxx
@@ -450,7 +450,7 @@ void AtEventManager::NextEvent()
       cArray = dynamic_cast<TClonesArray *>(fRootManager->GetObject("AtEventH"));
       // cArray = dynamic_cast<TObject *>(fRootManager->GetObject("AtEventH"));
       cevent = dynamic_cast<AtEvent *>(cArray->At(0));
-      gated = cevent->IsInGate();
+      gated = cevent->GetIsExtGate();
    }
 
    std::cout << " Event number : " << fEntry << std::endl;
@@ -474,7 +474,7 @@ void AtEventManager::PrevEvent()
       cArray = dynamic_cast<TClonesArray *>(fRootManager->GetObject("AtEventH"));
       // cArray = dynamic_cast<TObject *>(fRootManager->GetObject("AtEventH"));
       cevent = dynamic_cast<AtEvent *>(cArray->At(0));
-      gated = cevent->IsInGate();
+      gated = cevent->GetIsExtGate();
    }
 
    std::cout << " Event number : " << fEntry << std::endl;

--- a/AtEventDisplay/Deprecated/AtEventManagerS800.cxx
+++ b/AtEventDisplay/Deprecated/AtEventManagerS800.cxx
@@ -425,7 +425,7 @@ void AtEventManagerS800::NextEvent()
       fRootManager->ReadEvent(fEntry);
       cArray = dynamic_cast<TClonesArray *>(fRootManager->GetObject("AtEventH"));
       cevent = dynamic_cast<AtEvent *>(cArray->At(0));
-      gated = cevent->IsInGate();
+      gated = cevent->GetIsExtGate();
    }
 
    std::cout << " Event number : " << fEntry << std::endl;
@@ -448,7 +448,7 @@ void AtEventManagerS800::PrevEvent()
       fRootManager->ReadEvent(fEntry);
       cArray = dynamic_cast<TClonesArray *>(fRootManager->GetObject("AtEventH"));
       cevent = dynamic_cast<AtEvent *>(cArray->At(0));
-      gated = cevent->IsInGate();
+      gated = cevent->GetIsExtGate();
    }
 
    std::cout << " Event number : " << fEntry << std::endl;

--- a/AtReconstruction/AtFilterTask.cxx
+++ b/AtReconstruction/AtFilterTask.cxx
@@ -1,6 +1,7 @@
 #include "AtFilterTask.h"
 
 #include "AtAuxPad.h"
+#include "AtBaseEvent.h"
 #include "AtFilter.h"
 #include "AtPadReference.h" // for operator<<
 #include "AtRawEvent.h"

--- a/AtReconstruction/AtFitter/AtFitter.cxx
+++ b/AtReconstruction/AtFitter/AtFitter.cxx
@@ -142,7 +142,7 @@ Bool_t AtFITTER::AtFitter::MergeTracks(std::vector<AtTrack *> *trackCandSource, 
                    << trackToMerge->GetTrackID() << "\n";
          for (const auto &hit : trackToMerge->GetHitArray()) {
 
-            vertexTrack->AddHit(hit);
+            vertexTrack->AddHit(hit->Clone()); // TODO: Look at code and see if this can be a move instead of a copy
             ++addHitCnt;
          }
 
@@ -184,7 +184,7 @@ AtFITTER::AtFitter::MergeTracks(std::vector<AtTrack> *trackCandSource, std::vect
 
    for (auto trackCand : *trackCandSource) {
       Double_t thetaCand = trackCand.GetGeoTheta();
-      auto hitArrayCand = trackCand.GetHitArray();
+      auto &hitArrayCand = trackCand.GetHitArray();
       std::pair<Double_t, Double_t> centerCand = trackCand.GetGeoCenter();
 
       AtTrack track = trackCand;
@@ -200,7 +200,7 @@ AtFITTER::AtFitter::MergeTracks(std::vector<AtTrack> *trackCandSource, std::vect
 
       for (auto trackJunk : *trackJunkSource) {
          Double_t thetaJunk = trackJunk.GetGeoTheta();
-         auto hitArrayJunk = trackJunk.GetHitArray();
+         auto &hitArrayJunk = trackJunk.GetHitArray();
          std::pair<Double_t, Double_t> centerJunk = trackJunk.GetGeoCenter();
 
          if (simulationConv) {
@@ -235,7 +235,7 @@ AtFITTER::AtFitter::MergeTracks(std::vector<AtTrack> *trackCandSource, std::vect
 
                   for (const auto &hit : hitArrayJunk) {
 
-                     track.AddHit(hit);
+                     track.AddHit(hit->Clone());
                      ++jnkHitCnt;
                   }
             }

--- a/AtReconstruction/AtFitter/AtGenfit.cxx
+++ b/AtReconstruction/AtFitter/AtGenfit.cxx
@@ -5,6 +5,7 @@
 #include "AtTrack.h"
 
 #include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h> // for XYZPoint
 #include <RKTrackRep.h>
 #include <TClonesArray.h>
 #include <TDatabasePDG.h>
@@ -41,11 +42,12 @@
 #include <iostream>
 #include <tuple>
 #include <utility>
-
 constexpr auto cRED = "\033[1;31m";
 constexpr auto cYELLOW = "\033[1;33m";
 constexpr auto cNORMAL = "\033[0m";
 constexpr auto cGREEN = "\033[1;32m";
+
+using XYZPoint = ROOT::Math::XYZPoint;
 
 AtFITTER::AtGenfit::AtGenfit(Float_t magfield, Float_t minbrho, Float_t maxbrho, std::string eLossFile,
                              Float_t gasMediumDensity, Int_t pdg, Int_t minit, Int_t maxit)

--- a/AtReconstruction/AtPSAtask.cxx
+++ b/AtReconstruction/AtPSAtask.cxx
@@ -90,7 +90,7 @@ void AtPSAtask::Exec(Option_t *opt)
 
    auto *rawEvent = dynamic_cast<AtRawEvent *>(fRawEventArray->At(0));
    auto *event = dynamic_cast<AtEvent *>(fEventArray.ConstructedAt(0, "C")); // Get and clear old event
-   event->CopyFrom(*rawEvent);
+   *event = *rawEvent;
 
    if (!rawEvent->IsGood()) {
       LOG(debug) << "Event " << rawEvent->GetEventID() << " is not good, skipping PSA";

--- a/AtReconstruction/AtPatternRecognition/AtPRA.h
+++ b/AtReconstruction/AtPatternRecognition/AtPRA.h
@@ -68,7 +68,7 @@ public:
    virtual std::unique_ptr<AtPatternEvent> FindTracks(AtEvent &event) = 0;
 
    void PruneTrack(AtTrack &track);
-   bool kNN(const std::vector<AtHit> &hits, AtHit &hit, int k);
+   bool kNN(const std::vector<std::unique_ptr<AtHit>> &hits, AtHit &hit, int k);
 
 protected:
    // Functions that need to be moved to another class. They assume a curved track

--- a/AtReconstruction/AtSpaceChargeCorrectionTask.cxx
+++ b/AtReconstruction/AtSpaceChargeCorrectionTask.cxx
@@ -67,7 +67,8 @@ void AtSpaceChargeCorrectionTask::Exec(Option_t *opt)
 
    auto inputEvent = dynamic_cast<AtEvent *>(fInputEventArray->At(0));
    auto outputEvent = dynamic_cast<AtEvent *>(fOutputEventArray.ConstructedAt(0));
-   outputEvent->CopyFrom(*inputEvent);
+   *outputEvent = *inputEvent;
+   outputEvent->ClearHits();
 
    for (auto &inHit : inputEvent->GetHits()) {
       XYZPoint newPosition;

--- a/AtTools/AtTrackTransformer.cxx
+++ b/AtTools/AtTrackTransformer.cxx
@@ -1,10 +1,12 @@
 #include "AtTrackTransformer.h"
 // IWYU pragma: no_include <ext/alloc_traits.h>
+#include "AtContainerManip.h"
 #include "AtHit.h"        // for AtHit, AtHit::XYZPoint
 #include "AtHitCluster.h" // for AtHitCluster
 #include "AtTrack.h"      // for XYZPoint, AtTrack
 
-#include <Math/Point3D.h>   // for PositionVector3D, Cart...
+#include <Math/Point3D.h> // for PositionVector3D, Cart...
+#include <Math/Point3Dfwd.h>
 #include <Math/Vector3D.h>  // for DisplacementVector3D
 #include <TMath.h>          // for Power, Sqrt, ATan2, Pi
 #include <TMatrixDSymfwd.h> // for TMatrixDSym
@@ -18,10 +20,11 @@
 
 AtTools::AtTrackTransformer::AtTrackTransformer() = default;
 AtTools::AtTrackTransformer::~AtTrackTransformer() = default;
+using XYZPoint = ROOT::Math::XYZPoint;
 
 void AtTools::AtTrackTransformer::ClusterizeSmooth3D(AtTrack &track, Float_t distance, Float_t radius)
 {
-   std::vector<AtHit> hitArray = track.GetHitArray();
+   std::vector<AtHit> hitArray = track.GetHitArrayObject();
    std::vector<AtHit> hitTBArray;
    int clusterID = 0;
 

--- a/AtTools/ElectronicResponse/AtROOTresponse.cxx
+++ b/AtTools/ElectronicResponse/AtROOTresponse.cxx
@@ -5,6 +5,9 @@
 
 #include <TFile.h>
 #include <TObject.h>
+
+#include <utility> // for move
+
 using namespace ElectronicResponse;
 
 AtRootResponse::AtRootResponse(double tbTime, std::string filePath, std::string objectName) : fTBTime(tbTime)
@@ -17,7 +20,7 @@ AtRootResponse::AtRootResponse(double tbTime, std::string filePath, std::string 
       throw std::invalid_argument("objectName");
    fResponse = *event;
 }
-AtRootResponse::AtRootResponse(double tbTime, const AtRawEvent &response) : fTBTime(tbTime), fResponse(response) {}
+AtRootResponse::AtRootResponse(double tbTime, AtRawEvent response) : fTBTime(tbTime), fResponse(std::move(response)) {}
 
 double AtRootResponse::GetResponse(int padNum, double time) const
 {

--- a/AtTools/ElectronicResponse/AtROOTresponse.h
+++ b/AtTools/ElectronicResponse/AtROOTresponse.h
@@ -18,7 +18,7 @@ protected:
    double fTBTime;
 
 public:
-   AtRootResponse(double tbTime, const AtRawEvent &response);
+   AtRootResponse(double tbTime, AtRawEvent response);
    AtRootResponse(double tbTime, std::string filePath, std::string objectName);
 
    virtual double GetResponse(double time) const override

--- a/macro/e12014/adam/spaceCharge/run_eve.C
+++ b/macro/e12014/adam/spaceCharge/run_eve.C
@@ -38,15 +38,13 @@ void run_eve(int runNum = 206, TString OutputDataFile = "output.reco_display.roo
 
    auto fMap = std::make_shared<AtTpcMap>();
    fMap->ParseXMLMap(mapDir.Data());
-   AtEventManager *eveMan = new AtEventManager();
-   AtEventDrawTask *eve = new AtEventDrawTask();
-   eve->SetMap(fMap);
-   eve->Set3DHitStyleBox();
-   eve->SetMultiHit(100); // Set the maximum number of multihits in the visualization
-   eve->SetRawEventBranch("AtRawEventFiltered");
-   eve->SetEventBranch("AtEventFiltered");
-   eve->SetCorrectedEventBranch("AtEventCorrected");
-   eveMan->AddTask(eve);
+
+   AtViewerManager *eveMan = new AtViewerManager(fMap);
+
+   auto tabMain = std::make_unique<AtTabMain>();
+   tabMain->SetMultiHit(100); // Set the maximum number of multihits in the visualization
+   eveMan->AddTab(std::move(tabMain));
+
    eveMan->Init();
 
    std::cout << "Finished init" << std::endl;

--- a/macro/e12014/adam/spaceCharge/unpack.C
+++ b/macro/e12014/adam/spaceCharge/unpack.C
@@ -3,15 +3,24 @@ bool reduceFunc(AtRawEvent *evt)
    return (evt->GetNumPads() > 300) && evt->IsGood();
 }
 
-double lineField(double r, double z)
+double EField2(double rho, double z)
 {
-   double lambda = 5.28e-8;               // SI
+   double lambda = 2.35e-6;               // SI
+   constexpr double rBeam = 2.0 / 100;    // in *m*
    constexpr double eps = 8.85418782E-12; // SI
    constexpr double pi = 3.14159265358979;
    constexpr double eps2pi = 2 * pi * eps;
-   r /= 100.;                        // Convert units from cm to m
-   auto field = lambda / eps2pi / r; // v/m
-   return field / 100.;              // V/cm
+   rho /= 100.; // Convert units from cm to m
+   z /= 100.;   // Convert units from cm to m
+
+   double field;
+   if (rho > rBeam)
+      field = lambda / eps2pi / rho * (z / 1.); // v/m
+   else
+      // field = lambda / eps2pi / rBeam / rBeam * rho * (z/1.); // v/m
+      field = 0;
+   return field / 100.; // V/cm
+                        // return field;
 }
 
 // Requires the TPC run number
@@ -108,7 +117,7 @@ void unpack(int runNumber = 206)
 
    // Add SC Model
    // auto SCModel = std::make_unique<AtLineChargeModel>();
-   auto SCModel = std::make_unique<AtRadialChargeModel>(&lineField);
+   auto SCModel = std::make_unique<AtRadialChargeModel>(&EField2);
    auto SCTask = new AtSpaceChargeCorrectionTask(std::move(SCModel));
    SCTask->SetInputBranchName("AtEventFiltered");
 

--- a/macro/e12014/adam/unpack/README.md
+++ b/macro/e12014/adam/unpack/README.md
@@ -1,0 +1,8 @@
+# Unpacking many runs
+
+You can unpack many runs at once like:
+```
+./parallel --jobs 5 --joblog ./log.150 < 150torr.txt
+```
+
+where `--jobs` sets the maximum number of jobs to run at once. `--joblog ./fileName` sets the log file which will save the command, runtime, and return/error code. The file piped in contains each command to run (one per line).


### PR DESCRIPTION
Add AtBaseEvent as the base class for all event types. Will store information common across events (event ID, etc).

Add copy-swap idiom to all event types and implement the Clear() function.

Move AtRawEvent, AtEvent, and AtPatternEvent to inheriting AtBaseEvent.