### PR TITLE
Fix ROOT dictionary generation

### DIFF
--- a/AtTools/DataCleaning/AtDataCleaner.h
+++ b/AtTools/DataCleaning/AtDataCleaner.h
@@ -1,11 +1,10 @@
-#ifndef ATKNN_H
-#define ATKNN_H
+#ifndef _ATDATACLEANER_H
+#define _ATDATACLEANER_H
 
-#include "AtHit.h"
+class AtHit;
 
 #include <memory>
 #include <vector>
-class AtHit;
 
 namespace AtTools {
 
@@ -32,4 +31,4 @@ public:
 
 } // namespace AtTools
 
-#endif // ATKNN_H
+#endif // _ATDATACLEANER_H

--- a/AtTools/DataCleaning/AtkNN.cxx
+++ b/AtTools/DataCleaning/AtkNN.cxx
@@ -1,7 +1,9 @@
 #include "AtkNN.h"
 
+#include "AtHit.h"
 namespace AtTools {
 namespace DataCleaning {
+
 HitCloud AtkNN::CleanData(const HitCloud &hits)
 {
    HitCloud ret;

--- a/AtTools/DataCleaning/AtkNN.h
+++ b/AtTools/DataCleaning/AtkNN.h
@@ -1,3 +1,6 @@
+#ifndef ATKNN_H
+#define ATKNN_H
+
 #include "AtDataCleaner.h"
 
 namespace AtTools {
@@ -23,3 +26,5 @@ public:
 } // namespace DataCleaning
 
 } // namespace AtTools
+
+#endif // ATKNN_HH


### PR DESCRIPTION
ROOT requires all headers end in a newline, otherwise the dictionary generation code can comment out part of your header guard.