### PR TITLE
Add new unpacker for updated HDF5 merger

### DIFF
--- a/AtUnpack/AtFRIBLinkedUnpacker.cxx
+++ b/AtUnpack/AtFRIBLinkedUnpacker.cxx
@@ -8,6 +8,7 @@
 
 #include <FairLogger.h>
 
+#include <H5Apublic.h>
 #include <H5Gpublic.h>
 #include <H5Ppublic.h>
 
@@ -36,5 +37,111 @@ void AtFRIBLinkedHDFUnpacker::setFirstAndLastEventNum()
    hsize_t num_objs;
    H5Gget_num_objs(_group, &num_objs);
    fLastEvent = num_objs - 1;
-   LOG(info) << "Events: " << fFirstEvent << " to " << fLastEvent;
+   LOG(debug) << "Events: " << fFirstEvent << " to " << fLastEvent;
+};
+
+void AtFRIBLinkedHDFUnpacker::setEventIDAndTimestamps()
+{
+   fRawEvent->SetEventID(fEventID);
+
+   // Try to pull the timestamp
+   try {
+
+      // Open the dataset associated with the internal event id
+      std::string dataset_name = TString::Format("event_%lld/get_traces", fDataEventID).Data();
+      auto dataset_dims = open_dataset(_group, dataset_name.c_str());
+      _dataset = std::get<0>(dataset_dims);
+
+      auto _attr = H5Aopen(_dataset, "timestamp", H5P_DEFAULT);
+      if (_attr < 0) {
+         LOG(error) << "Could not open timestamp attribute for event " << fDataEventID;
+         fRawEvent->SetNumberOfTimestamps(0);
+         return;
+      } else {
+         unsigned long long timestamp;
+         H5Aread(_attr, H5T_NATIVE_ULLONG, &timestamp);
+         H5Aclose(_attr);
+         LOG(debug) << "Setting timestamp " << timestamp << " for event " << fDataEventID;
+         fRawEvent->SetNumberOfTimestamps(1);
+         fRawEvent->SetTimestamp(timestamp, 0);
+      }
+
+      _attr = H5Aopen(_dataset, "timestamp_other", H5P_DEFAULT);
+      if (_attr < 0) {
+         LOG(error) << "Could not open timestamp_other attribute for event " << fDataEventID;
+         return;
+      } else {
+         unsigned long long timestamp;
+         H5Aread(_attr, H5T_NATIVE_ULLONG, &timestamp);
+         H5Aclose(_attr);
+         LOG(debug) << "Setting timestamp_other " << timestamp << " for event " << fDataEventID;
+         fRawEvent->SetNumberOfTimestamps(2);
+         fRawEvent->SetTimestamp(timestamp, 1);
+      }
+
+   } catch (const std::exception &e) {
+      LOG(error) << "Failed to load the header, not setting timestamps.";
+      fRawEvent->SetNumberOfTimestamps(0);
+   }
+}
+
+std::size_t AtFRIBLinkedHDFUnpacker::n_pads(std::string i_raw_event)
+{
+   std::string dataset_name = i_raw_event + "/get_traces";
+   auto dataset_dims = open_dataset(_group, dataset_name.c_str());
+   if (std::get<0>(dataset_dims) == 0)
+      return 0;
+   _dataset = std::get<0>(dataset_dims);
+   return std::get<1>(dataset_dims)[0];
+};
+
+std::size_t AtFRIBLinkedHDFUnpacker::n_aux(std::string i_raw_event)
+{
+   std::string dataset_name = i_raw_event + fFribPath;
+   auto dataset_dims = open_dataset(_group, dataset_name.c_str());
+   if (std::get<0>(dataset_dims) == 0)
+      return 0;
+   _dataset = std::get<0>(dataset_dims);
+   return std::get<1>(dataset_dims)[1];
+};
+
+void AtFRIBLinkedHDFUnpacker::processAux(std::size_t padIndex)
+{
+   int16_t data[2048];
+   hsize_t counts[2] = {2048, 1};
+   hsize_t offsets[2] = {0, padIndex};
+   hsize_t dims_out[2] = {2048, 1};
+   read_slab<int16_t>(_dataset, counts, offsets, dims_out, data);
+   std::vector<int16_t> rawadc(data, data + 2048);
+
+   auto trace = fRawEvent->AddGenericTrace(padIndex);
+   auto baseline = getBaseline(rawadc);
+   for (Int_t iTb = 0; iTb < 2048; iTb++) {
+      trace->SetRawADC(iTb, rawadc.at(iTb));
+      trace->SetADC(iTb, rawadc.at(iTb) - baseline);
+
+      if (padIndex == 0 && iTb > 2000)
+         LOG(debug) << "Aux trace " << iTb << " " << rawadc.at(iTb);
+   }
+};
+
+void AtFRIBLinkedHDFUnpacker::processData()
+{
+   TString event_name = TString::Format("event_%lld", fDataEventID);
+   fRawEvent->SetEventName(event_name.Data());
+
+   // Loop through and grab all of the pads in the event
+   std::size_t npads = n_pads(event_name.Data());
+   LOG(info) << "Unpacking " << npads << " pads in event " << fDataEventID;
+   for (std::size_t i = 0; i < npads; i++) {
+      processPad(i);
+   }
+
+   // Loop through and grab all of the generic traces in the event
+   auto nAux = n_aux(event_name.Data());
+   LOG(info) << "Unpacking " << nAux << " generic traces in event " << fDataEventID;
+   for (auto i = 0; i < nAux; ++i)
+      processAux(i);
+
+   end_raw_event(); // Close dataset
 };

--- a/AtUnpack/AtFRIBLinkedUnpacker.cxx
+++ b/AtUnpack/AtFRIBLinkedUnpacker.cxx
@@ -1,0 +1,40 @@
+#include "AtFRIBLinkedUnpacker.h"
+
+#include "AtGenericTrace.h" // for AtGenericTrace
+#include "AtMap.h"
+#include "AtPad.h"
+#include "AtPadReference.h"
+#include "AtRawEvent.h"
+
+#include <FairLogger.h>
+
+#include <H5Gpublic.h>
+#include <H5Ppublic.h>
+
+ClassImp(AtFRIBLinkedHDFUnpacker);
+
+std::size_t AtFRIBLinkedHDFUnpacker::open(char const *file)
+{
+   auto f = open_file(file, AtHDFUnpacker::IO_MODE::READ);
+   if (f == 0)
+      return 0;
+   _file = f;
+
+   auto group_n_entries = open_group(f, "events");
+   if (std::get<0>(group_n_entries) == -1)
+      return 0;
+   _group = std::get<0>(group_n_entries);
+   setFirstAndLastEventNum();
+   return std::get<1>(group_n_entries);
+};
+
+void AtFRIBLinkedHDFUnpacker::setFirstAndLastEventNum()
+{
+   // Assume that events are 0 indexed and contiguous
+   fFirstEvent = 0;
+
+   hsize_t num_objs;
+   H5Gget_num_objs(_group, &num_objs);
+   fLastEvent = num_objs - 1;
+   LOG(info) << "Events: " << fFirstEvent << " to " << fLastEvent;
+};

--- a/AtUnpack/AtFRIBLinkedUnpacker.h
+++ b/AtUnpack/AtFRIBLinkedUnpacker.h
@@ -15,7 +15,7 @@ protected:
    std::string fFribPath = "/frib_physics/1903";
 
 public:
-   AtFRIBLinkedHDFUnpacker(mapPtr map) : AtHDFUnpacker(map) {};
+   AtFRIBLinkedHDFUnpacker(mapPtr map) : AtHDFUnpacker(map){};
    ~AtFRIBLinkedHDFUnpacker() = default;
 
 protected:

--- a/AtUnpack/AtFRIBLinkedUnpacker.h
+++ b/AtUnpack/AtFRIBLinkedUnpacker.h
@@ -10,18 +10,23 @@
  */
 
 class AtFRIBLinkedHDFUnpacker : public AtHDFUnpacker {
+
+protected:
+   std::string fFribPath = "/frib_physics/1903";
+
 public:
    AtFRIBLinkedHDFUnpacker(mapPtr map) : AtHDFUnpacker(map) {};
    ~AtFRIBLinkedHDFUnpacker() = default;
 
-   void Init() override;
-
 protected:
    virtual std::size_t open(char const *file) override;
    virtual void setFirstAndLastEventNum() override;
-   // virtual void processData() override;
+   virtual void setEventIDAndTimestamps() override;
+   virtual void processData() override;
    // virtual void processPad(std::size_t padIndex) override;
-   // virtual std::size_t n_pads(std::string i_raw_event) override;
+   virtual std::size_t n_pads(std::string i_raw_event) override;
+   std::size_t n_aux(std::string i_raw_event);
+   void processAux(std::size_t auxIndex);
    // virtual std::vector<int16_t> pad_raw_data(std::size_t i_pad) override;
 
    ClassDefOverride(AtFRIBLinkedHDFUnpacker, 1);

--- a/AtUnpack/AtFRIBLinkedUnpacker.h
+++ b/AtUnpack/AtFRIBLinkedUnpacker.h
@@ -1,0 +1,30 @@
+#ifndef ATFRIBLINKEDHDFUNPACKER_H
+#define ATFRIBLINKEDHDFUNPACKER_H
+
+#include "AtHDFUnpacker.h"
+/**
+ * @brief  Unpacker for HDF5 files with FRIB already linked by timestamp.
+ *
+ * This class is used to unpack data from HDF5 files that have already been linked by timestamp
+ * and are using the FRIB DAQ to load in any "aux" channels with the 2024 sample digitizer.
+ */
+
+class AtFRIBLinkedHDFUnpacker : public AtHDFUnpacker {
+public:
+   AtFRIBLinkedHDFUnpacker(mapPtr map) : AtHDFUnpacker(map) {};
+   ~AtFRIBLinkedHDFUnpacker() = default;
+
+   void Init() override;
+
+protected:
+   virtual std::size_t open(char const *file) override;
+   virtual void setFirstAndLastEventNum() override;
+   // virtual void processData() override;
+   // virtual void processPad(std::size_t padIndex) override;
+   // virtual std::size_t n_pads(std::string i_raw_event) override;
+   // virtual std::vector<int16_t> pad_raw_data(std::size_t i_pad) override;
+
+   ClassDefOverride(AtFRIBLinkedHDFUnpacker, 1);
+};
+
+#endif // ATFRIBLINKEDHDFUNPACKER_H

--- a/AtUnpack/AtHDFUnpacker.cxx
+++ b/AtUnpack/AtHDFUnpacker.cxx
@@ -261,6 +261,12 @@ void AtHDFUnpacker::setFirstAndLastEventNum()
    }
    LOG(info) << "Events: " << fFirstEvent << " to " << fLastEvent;
 }
+
+/**
+ * @brief Open the file and sets the first/last event number in the file
+ *
+ * @return the number of events in the file
+ */
 std::size_t AtHDFUnpacker::open(char const *file)
 {
    auto f = open_file(file, AtHDFUnpacker::IO_MODE::READ);

--- a/AtUnpack/AtHDFUnpacker.h
+++ b/AtUnpack/AtHDFUnpacker.h
@@ -61,8 +61,10 @@ protected:
    virtual std::vector<int16_t> pad_raw_data(std::size_t i_pad);
    hid_t open_file(char const *file, IO_MODE mode);
    std::tuple<hid_t, hsize_t> open_group(hid_t fileId, char const *group);
-   std::tuple<hid_t, std::vector<hsize_t>> open_dataset(hid_t locId, char const *dataset);
-   // Returns the id of the dataspace and the dimesnions in the vector
+   std::tuple<hid_t, std::vector<hsize_t>>
+   open_dataset(hid_t locId, char const *dataset); /// Returns the id of the dataspace and the dimesnions in the vector
+   virtual void setEventIDAndTimestamps();
+
    void close_file(hid_t file);
    void close_group(hid_t group);
    void close_dataset(hid_t dataset);
@@ -81,12 +83,10 @@ protected:
    }
 
    hid_t _file{};
-   hid_t _group{};
+   hid_t _group{}; /// The group that contains the events (get in original unpacker)
    hid_t _dataset{};
    std::vector<std::string> _eventsbyname;
 
-private:
-   void setEventIDAndTimestamps();
    AtPad *createPadAndSetIsAux(const AtPadReference &padRef);
    void setDimensions(AtPad *pad);
    void setAdc(AtPad *pad, const std::vector<int16_t> &data);

--- a/AtUnpack/AtUnpackLinkDef.h
+++ b/AtUnpack/AtUnpackLinkDef.h
@@ -20,7 +20,9 @@
 #pragma link C++ class AtUnpacker + ;
 #pragma link C++ class AtHDFUnpacker + ;
 #pragma link C++ class AtFRIBHDFUnpacker + ;
+#pragma link C++ class AtFRIBLinkedHDFUnpacker + ;
 #pragma link C++ class AtROOTUnpacker + ;
 #pragma link C++ class AtGRAWUnpacker + ;
 #pragma link C++ class AtUnpackTask + ;
+
 #endif

--- a/AtUnpack/CMakeLists.txt
+++ b/AtUnpack/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SRCS
   AtUnpacker.cxx
   AtHDFUnpacker.cxx
   AtFRIBHDFUnpacker.cxx
+  AtFRIBLinkedUnpacker.cxx
   AtROOTUnpacker.cxx
   AtGRAWUnpacker.cxx
 

--- a/macro/tests/AT-TPC/run_unpack_linked.C
+++ b/macro/tests/AT-TPC/run_unpack_linked.C
@@ -1,0 +1,92 @@
+
+// Requires the TPC run number
+void run_unpack_linked(int runNumber = 25)
+{
+   // Load the library for unpacking and reconstruction
+   gSystem->Load("libAtReconstruction.so");
+
+   TStopwatch timer;
+   timer.Start();
+
+   // Set the input/output directories
+   TString inputDir = "./data";
+   TString outDir = "./data";
+
+   // Set the in/out files
+   TString inputFile = inputDir + TString::Format("/run_%04d.h5", runNumber);
+   TString outputFile = outDir + TString::Format("/run_%04d.root", runNumber);
+
+   std::cout << "Unpacking run " << runNumber << " from: " << inputFile << std::endl;
+   std::cout << "Saving in: " << outputFile << std::endl;
+
+   // Set the mapping for the TPC
+   TString mapFile = "e12014_pad_mapping.xml"; //"Lookup20150611.xml";
+   TString parameterFile = "ATTPC.e12014.par";
+
+   // Set directories
+   TString dir = gSystem->Getenv("VMCWORKDIR");
+   TString mapDir = dir + "/scripts/" + mapFile;
+   TString geomDir = dir + "/geometry/";
+   gSystem->Setenv("GEOMPATH", geomDir.Data());
+   TString digiParFile = dir + "/parameters/" + parameterFile;
+   TString geoManFile = dir + "/geometry/ATTPC_v1.1.root";
+
+   // Create a run
+   FairRunAna *run = new FairRunAna();
+   run->SetSink(new FairRootFileSink(outputFile));
+   run->SetGeomFile(geoManFile);
+
+   // Set the parameter file
+   FairRuntimeDb *rtdb = run->GetRuntimeDb();
+   FairParAsciiFileIo *parIo1 = new FairParAsciiFileIo();
+
+   std::cout << "Setting par file: " << digiParFile << std::endl;
+   parIo1->open(digiParFile.Data(), "in");
+   rtdb->setFirstInput(parIo1);
+   std::cout << "Getting containers..." << std::endl;
+   // We must get the container before initializing a run
+   rtdb->getContainer("AtDigiPar");
+
+   // Create the detector map
+   auto fAtMapPtr = std::make_shared<AtTpcMap>();
+   fAtMapPtr->ParseXMLMap(mapDir.Data());
+   fAtMapPtr->GeneratePadPlane();
+
+   // Create the unpacker task
+   auto unpacker = std::make_unique<AtFRIBLinkedHDFUnpacker>(fAtMapPtr);
+   unpacker->SetInputFileName(inputFile.Data());
+   unpacker->SetBaseLineSubtraction(true);
+
+   auto unpackTask = new AtUnpackTask(std::move(unpacker));
+   unpackTask->SetPersistence(true);
+
+   // Add unpacker to the run
+   run->AddTask(unpackTask);
+
+   std::cout << "***** Starting Init ******" << std::endl;
+   run->Init();
+   std::cout << "***** Ending Init ******" << std::endl;
+
+   // Get the number of events and unpack the whole run
+   auto numEvents = unpackTask->GetNumEvents();
+
+   // numEvents = 1700;//217;
+   // numEvents = 5;
+
+   std::cout << "Unpacking " << numEvents << " events. " << std::endl;
+
+   // return;
+   run->Run(0, numEvents);
+
+   std::cout << std::endl << std::endl;
+   std::cout << "Done unpacking events" << std::endl << std::endl;
+   std::cout << "- Output file : " << outputFile << std::endl << std::endl;
+   // -----   Finish   -------------------------------------------------------
+   timer.Stop();
+   Double_t rtime = timer.RealTime();
+   Double_t ctime = timer.CpuTime();
+   cout << endl << endl;
+   cout << "Real time " << rtime << " s, CPU time " << ctime << " s" << endl;
+   cout << endl;
+   // ------------------------------------------------------------------------
+}

--- a/macro/tests/AT-TPC/run_unpack_linked.C
+++ b/macro/tests/AT-TPC/run_unpack_linked.C
@@ -76,7 +76,7 @@ void run_unpack_linked(int runNumber = 25)
    std::cout << "Unpacking " << numEvents << " events. " << std::endl;
 
    // return;
-   run->Run(0, numEvents);
+   run->Run(0, 1);
 
    std::cout << std::endl << std::endl;
    std::cout << "Done unpacking events" << std::endl << std::endl;


### PR DESCRIPTION
New unpacker that loads the merger HDF5 file. Will unpack all pads and copy all aux pads into generic traces. 