### PR TITLE
Visualize fits on pad plane

### DIFF
--- a/AtData/AtDataLinkDef.h
+++ b/AtData/AtDataLinkDef.h
@@ -38,6 +38,8 @@
 #pragma link C++ class AtPatterns::AtPatternCircle2D + ;
 #pragma link C++ class AtPatterns::AtPatternY + ;
 #pragma link C++ class AtPatterns::AtPatternFission + ;
+#pragma link C++ class AtPadPlaneElement + ;
+#pragma link C++ class AtPadPlaneCircle + ;
 #pragma link C++ enum AtPatterns::PatternType;
 #pragma link C++ function AtPatterns::CreatePattern;
 

--- a/AtData/AtPattern/AtPadPlaneElement.cxx
+++ b/AtData/AtPattern/AtPadPlaneElement.cxx
@@ -1,0 +1,1 @@
+#include "AtPadPlaneElement.h"

--- a/AtData/AtPattern/AtPadPlaneElement.h
+++ b/AtData/AtPattern/AtPadPlaneElement.h
@@ -1,0 +1,39 @@
+#ifndef ATPADPLANELEMENT_H
+#define ATPADPLANELEMENT_H
+
+#include <TArc.h>
+#include <TObject.h> // for TObject
+
+#include <memory>
+
+/**
+ * @brief Base class for elements that can be drawn on the pad plane.
+ *
+ * These will share the same base elements as normal drawable classes.
+ */
+class AtPadPlaneElement {
+public:
+   AtPadPlaneElement() = default;
+   virtual ~AtPadPlaneElement() = default;
+
+   virtual void Draw() const = 0;
+   virtual void SetLineColor(Color_t color) = 0;
+   virtual void SetLineWidth(Width_t width) = 0;
+   virtual void SetLineStyle(Style_t style) = 0;
+};
+
+class AtPadPlaneCircle : public AtPadPlaneElement {
+protected:
+   std::unique_ptr<TArc> fCircle;
+
+public:
+   AtPadPlaneCircle(float x, float y, float r) : fCircle(std::make_unique<TArc>(x, y, r)) {};
+   virtual ~AtPadPlaneCircle() = default;
+
+   virtual void Draw() const override { fCircle->Draw("SAME"); }
+   virtual void SetLineColor(Color_t color) override { fCircle->SetLineColor(color); }
+   virtual void SetLineWidth(Width_t width) override { fCircle->SetLineWidth(width); }
+   virtual void SetLineStyle(Style_t style) override { fCircle->SetLineStyle(style); }
+};
+
+#endif // #ifndef ATPADPLANELEMENT_H

--- a/AtData/AtPattern/AtPadPlaneElement.h
+++ b/AtData/AtPattern/AtPadPlaneElement.h
@@ -28,7 +28,7 @@ protected:
    std::unique_ptr<TArc> fCircle;
 
 public:
-   AtPadPlaneCircle(float x, float y, float r) : fCircle(std::make_unique<TArc>(x, y, r)) {};
+   AtPadPlaneCircle(float x, float y, float r) : fCircle(std::make_unique<TArc>(x, y, r)) {}
    virtual ~AtPadPlaneCircle() = default;
 
    virtual void Draw() const override { fCircle->Draw("SAME"); }

--- a/AtData/AtPattern/AtPadPlaneElement.h
+++ b/AtData/AtPattern/AtPadPlaneElement.h
@@ -20,6 +20,7 @@ public:
    virtual void SetLineColor(Color_t color) = 0;
    virtual void SetLineWidth(Width_t width) = 0;
    virtual void SetLineStyle(Style_t style) = 0;
+   virtual void SetFillStyle(Style_t style) = 0;
 };
 
 class AtPadPlaneCircle : public AtPadPlaneElement {
@@ -34,6 +35,7 @@ public:
    virtual void SetLineColor(Color_t color) override { fCircle->SetLineColor(color); }
    virtual void SetLineWidth(Width_t width) override { fCircle->SetLineWidth(width); }
    virtual void SetLineStyle(Style_t style) override { fCircle->SetLineStyle(style); }
+   virtual void SetFillStyle(Style_t style) override { fCircle->SetFillStyle(style); }
 };
 
 #endif // #ifndef ATPADPLANELEMENT_H

--- a/AtData/AtPattern/AtPattern.h
+++ b/AtData/AtPattern/AtPattern.h
@@ -1,6 +1,8 @@
 #ifndef ATPATTERN_H
 #define ATPATTERN_H
 
+#include "AtPadPlaneElement.h"
+
 #include <Math/Point3D.h>
 #include <Math/Point3Dfwd.h> // for XYZPoint
 #include <Rtypes.h>          // for Double_t, Int_t, THashConsistencyHolder, ClassDef
@@ -18,7 +20,6 @@ class TMemberInspector;
 class TEveLine;
 class TEveElement;
 class AtHit;
-
 /**
  * @defgroup AtPattern Track Patterns
  * @brief Track shapes in 3D space.
@@ -119,6 +120,13 @@ public:
     * Calls GetEveLine(double tMin, double tMax, int n) with reasonable defaults for the shape
     */
    virtual TEveElement *GetEveElement() const = 0;
+
+   /**
+    *  @brief Get visual representation of pattern on pad plane
+    *
+    * @return Representation of pattern on pad plane
+    */
+   virtual std::unique_ptr<AtPadPlaneElement> GetPadPlaneProjection() const { return nullptr; };
 
    virtual std::unique_ptr<AtPattern> Clone() const = 0;
 

--- a/AtData/AtPattern/AtPatternCircle2D.cxx
+++ b/AtData/AtPattern/AtPatternCircle2D.cxx
@@ -1,5 +1,7 @@
 #include "AtPatternCircle2D.h"
 
+#include "AtPadPlaneElement.h"
+
 #include <Math/Point2D.h>
 #include <Math/Point2Dfwd.h> // for XYPoint
 #include <Math/Point3D.h>
@@ -20,6 +22,11 @@ AtPatternCircle2D::AtPatternCircle2D() : AtPattern(3) {}
 TEveElement *AtPatternCircle2D::GetEveElement() const
 {
    return AtPattern::GetEveLine(0, 2 * M_PI, 1000);
+}
+
+std::unique_ptr<AtPadPlaneElement> AtPatterns::AtPatternCircle2D::GetPadPlaneProjection() const
+{
+   return std::make_unique<AtPadPlaneCircle>(GetCenter().X(), GetCenter().Y(), GetRadius());
 }
 
 void AtPatternCircle2D::DefinePattern(const std::vector<XYZPoint> &points)

--- a/AtData/AtPattern/AtPatternCircle2D.h
+++ b/AtData/AtPattern/AtPatternCircle2D.h
@@ -36,6 +36,7 @@ public:
    virtual XYZPoint GetPointAt(double theta) const override;
    virtual TEveElement *GetEveElement() const override;
    virtual std::unique_ptr<AtPattern> Clone() const override { return std::make_unique<AtPatternCircle2D>(*this); }
+   virtual std::unique_ptr<AtPadPlaneElement> GetPadPlaneProjection() const override;
 
 protected:
    virtual void FitPattern(const std::vector<XYZPoint> &points, const std::vector<double> &charge) override;

--- a/AtData/CMakeLists.txt
+++ b/AtData/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRCS
   AtPattern/AtPatternFission.cxx
   AtPattern/AtPatternRay.cxx
   AtPattern/AtPatternTypes.cxx
+  AtPattern/AtPadPlaneElement.cxx
 
   AtFittedTrack.cxx
   

--- a/AtEventDisplay/AtTabs/AtTabMain.cxx
+++ b/AtEventDisplay/AtTabs/AtTabMain.cxx
@@ -252,10 +252,12 @@ void AtTabMain::UpdatePatternEventElements()
       if (projection != nullptr) {
          projection->SetLineColor(GetTrackColor(i));
          projection->SetFillStyle(0);
-         fCvsPadPlane->cd();
-         projection->Draw();
-         fCvsPadPlane->Update();
-         fCvsPadPlane->Modified();
+         if (fDrawProjection) {
+            fCvsPadPlane->cd();
+            projection->Draw();
+            fCvsPadPlane->Update();
+            fCvsPadPlane->Modified();
+         }
          fPatternLines.push_back(std::move(projection));
       }
    }

--- a/AtEventDisplay/AtTabs/AtTabMain.cxx
+++ b/AtEventDisplay/AtTabs/AtTabMain.cxx
@@ -251,9 +251,11 @@ void AtTabMain::UpdatePatternEventElements()
       auto projection = tracks[i].GetPattern()->GetPadPlaneProjection();
       if (projection != nullptr) {
          projection->SetLineColor(GetTrackColor(i));
-         LOG(info) << "Adding projection of pattern " << i << " to pad plane";
+         projection->SetFillStyle(0);
          fCvsPadPlane->cd();
          projection->Draw();
+         fCvsPadPlane->Update();
+         fCvsPadPlane->Modified();
          fPatternLines.push_back(std::move(projection));
       }
    }

--- a/AtEventDisplay/AtTabs/AtTabMain.cxx
+++ b/AtEventDisplay/AtTabs/AtTabMain.cxx
@@ -21,6 +21,7 @@
 #include <TEveBrowser.h>         // for TEveBrowser
 #include <TEveEventManager.h>    // for TEveEventManager
 #include <TEveGeoNode.h>         // for TEveGeoTopNode
+#include <TEveLine.h>            // for TEveLine
 #include <TEveManager.h>         // for TEveManager, gEve
 #include <TEvePointSet.h>        // for TEvePointSet
 #include <TEveViewer.h>          // for TEveViewer
@@ -124,6 +125,8 @@ void AtTabMain::ExpandNumPatterns(int num)
 
       fPatternHitSets.push_back(std::move(trackSet));
    }
+
+   fPatternLines.resize(num);
 }
 
 Color_t AtTabMain::GetTrackColor(int i)
@@ -226,6 +229,7 @@ void AtTabMain::UpdatePatternEventElements()
 
    // Remove all the elements, and re-add them
    fEvePatternEvent->RemoveElements();
+   fPatternLines.clear();
    for (int i = 0; i < tracks.size(); ++i) {
       if (tracks[i].GetPattern() == nullptr)
          continue;
@@ -242,6 +246,16 @@ void AtTabMain::UpdatePatternEventElements()
       pattern->SetDestroyOnZeroRefCnt(false);
       pattern->SetMainColor(GetTrackColor(i));
       fEvePatternEvent->AddElement(pattern);
+
+      // Get the projection of the pattern on the pad plane
+      auto projection = tracks[i].GetPattern()->GetPadPlaneProjection();
+      if (projection != nullptr) {
+         projection->SetLineColor(GetTrackColor(i));
+         LOG(info) << "Adding projection of pattern " << i << " to pad plane";
+         fCvsPadPlane->cd();
+         projection->Draw();
+         fPatternLines.push_back(std::move(projection));
+      }
    }
 }
 

--- a/AtEventDisplay/AtTabs/AtTabMain.h
+++ b/AtEventDisplay/AtTabs/AtTabMain.h
@@ -69,7 +69,7 @@ public:
    ~AtTabMain();
    void InitTab() override;
 
-   void Exec() override {};
+   void Exec() override {}
    void Update(DataHandling::AtSubject *sub) override;
 
    void DumpEvent(std::string file);

--- a/AtEventDisplay/AtTabs/AtTabMain.h
+++ b/AtEventDisplay/AtTabs/AtTabMain.h
@@ -49,6 +49,7 @@ protected:
 
    Int_t fThreshold{0};    //< Min charge to draw hit
    Int_t fMaxHitMulti{10}; //< Max hits in a pad for hit to be drawn
+   Bool_t fDrawProjection{false};
 
    TAttMarker fHitAttr{kPink, kFullDotMedium, 1};
 
@@ -76,6 +77,7 @@ public:
    void SetThreshold(Int_t val) { fThreshold = val; }
    void SetHitAttributes(TAttMarker attr) { fHitAttr = std::move(attr); }
    void SetMultiHit(Int_t hitMax) { fMaxHitMulti = hitMax; }
+   void SetDrawProjection(Bool_t draw = true) { fDrawProjection = draw; }
 
    /**
     * This function is responsible for selecting the pad we are currently examining and passing

--- a/AtEventDisplay/AtTabs/AtTabMain.h
+++ b/AtEventDisplay/AtTabs/AtTabMain.h
@@ -1,6 +1,7 @@
 #ifndef ATTABMAIN_H
 #define ATTABMAIN_H
 #include "AtDataObserver.h"         // for Observer
+#include "AtPadPlaneElement.h"      // for AtPadPlaneElement
 #include "AtTabBase.h"              // for AtTabBase
 #include "AtViewerManagerSubject.h" // for AtPadNum
 
@@ -35,6 +36,7 @@ class AtTabMain : public AtTabBase, public DataHandling::AtObserver {
 protected:
    using TEvePointSetPtr = std::unique_ptr<TEvePointSet>;
    using TEveEventManagerPtr = std::unique_ptr<TEveEventManager>;
+   using AtPadPlaneElementPtr = std::unique_ptr<AtPadPlaneElement>;
 
    TEveEventManagerPtr fEveEvent{std::make_unique<TEveEventManager>("AtEvent")};
    TEvePointSetPtr fHitSet{std::make_unique<TEvePointSet>("Hits")}; //< AtEvent Hit Set
@@ -43,6 +45,7 @@ protected:
    TEvePointSetPtr fNoiseHitSet{std::make_unique<TEvePointSet>("Noise")}; //< AtPatternEvent Noise Set
    std::vector<TEvePointSetPtr> fPatternHitSets;
    std::vector<TEveElement> fPatterns;
+   std::vector<AtPadPlaneElementPtr> fPatternLines; /// Projection of AtPattern shape on pad plane.
 
    Int_t fThreshold{0};    //< Min charge to draw hit
    Int_t fMaxHitMulti{10}; //< Max hits in a pad for hit to be drawn
@@ -65,7 +68,7 @@ public:
    ~AtTabMain();
    void InitTab() override;
 
-   void Exec() override{};
+   void Exec() override {};
    void Update(DataHandling::AtSubject *sub) override;
 
    void DumpEvent(std::string file);


### PR DESCRIPTION
Add the ability to draw some AtPatterns (just circles right now) on the pad plane. 

Is off by default. Can be flipped on by calling `SetDrawProjection(true)` on the `AtTabMain` object in a `run_eve` script. That is,

```cpp
 auto tabMain = std::make_unique<AtTabMain>();
 tabMain->SetMultiHit(100); // Set the maximum number of multihits in the visualization
 tabMain->SetDrawProjection(true);
 eveMan->AddTab(std::move(tabMain));
```

![image](https://github.com/user-attachments/assets/18e2b978-cede-4654-a818-6717b7c04285)
