### PR TITLE
Add OpenKF to the AtReconstruction library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,4 +16,4 @@ jobs:
         source: '.'
         exclude: './macro ./scripts ./compiled ./resources ./include ./geometry'
         extensions: 'h,cxx,C'
-        clangFormatVersion: 16
+        clangFormatVersion: 17

--- a/AtReconstruction/AtFitter/OpenKF/examples/ego_motion_model_adapter/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/ego_motion_model_adapter/main.cpp
@@ -1,0 +1,183 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/kalman_filter.h"
+#include "motion_model/ego_motion_model.h"
+#include "types.h"
+
+static constexpr size_t DIM_X{5};  /// \vec{x} = [x, y, vx, vy, yaw]^T
+static constexpr size_t DIM_U{3};  /// \vec{u} = [steeringAngle, ds, dyaw]^T
+static constexpr size_t DIM_Z{2};
+
+using namespace kf;
+
+/// @brief This is an adapter example to show case how to convert from the
+/// 3-dimension state egomotion model to a higher or lower dimension state
+/// vector (e.g. 5-dimension state vector and 3-dimension input vector).
+class EgoMotionModelAdapter
+    : public motionmodel::MotionModelExtInput<DIM_X, DIM_U>
+{
+ public:
+  virtual Vector<DIM_X> f(
+      Vector<DIM_X> const& vecX, Vector<DIM_U> const& vecU,
+      Vector<DIM_X> const& /*vecQ = Vector<DIM_X>::Zero()*/) const override
+  {
+    Vector<3> tmpVecX;  // \vec{x} = [x, y, yaw]^T
+    tmpVecX << vecX[0], vecX[1], vecX[4];
+
+    Vector<2> tmpVecU;  // \vec{u} = [ds, dyaw]^T
+    tmpVecU << vecU[1], vecU[2];
+
+    motionmodel::EgoMotionModel const egoMotionModel;
+    tmpVecX = egoMotionModel.f(tmpVecX, tmpVecU);
+
+    Vector<DIM_X> vecXout;
+    vecXout[0] = tmpVecX[0];
+    vecXout[1] = tmpVecX[1];
+    vecXout[4] = tmpVecX[2];
+
+    return vecXout;
+  }
+
+  virtual Matrix<DIM_X, DIM_X> getProcessNoiseCov(
+      Vector<DIM_X> const& vecX, Vector<DIM_U> const& vecU) const override
+  {
+    // input idx -> output index mapping
+    // 0 -> 0
+    // 1 -> 1
+    // 2 -> 4
+    Vector<3> tmpVecX;
+    tmpVecX << vecX[0], vecX[1], vecX[4];
+
+    // input idx -> output index mapping
+    // 0 -> 1
+    // 1 -> 2
+    Vector<2> tmpVecU;
+    tmpVecU << vecU[1], vecU[2];
+
+    motionmodel::EgoMotionModel const egoMotionModel;
+
+    Matrix<3, 3> matQ = egoMotionModel.getProcessNoiseCov(tmpVecX, tmpVecU);
+
+    //        |q00    q01   x   x   q02|
+    //        |q10    q11   x   x   q12|         |q00   q01   q02|
+    // Qout = |  x      x   x   x     x| <- Q =  |q10   q11   q12|
+    //        |  x      x   x   x     x|         |q20   q21   q22|
+    //        |q20    q21   x   x   q22|
+
+    Matrix<DIM_X, DIM_X> matQout;
+    matQout(0, 0) = matQ(0, 0);
+    matQout(0, 1) = matQ(0, 1);
+    matQout(0, 4) = matQ(0, 2);
+    matQout(1, 0) = matQ(1, 0);
+    matQout(1, 1) = matQ(1, 1);
+    matQout(1, 4) = matQ(1, 2);
+    matQout(4, 0) = matQ(2, 0);
+    matQout(4, 1) = matQ(2, 1);
+    matQout(4, 4) = matQ(2, 1);
+
+    return matQout;
+  }
+
+  virtual Matrix<DIM_X, DIM_X> getInputNoiseCov(
+      Vector<DIM_X> const& vecX, Vector<DIM_U> const& vecU) const override
+  {
+    Vector<3> tmpVecX;
+    tmpVecX << vecX[0], vecX[1], vecX[4];
+
+    Vector<2> tmpVecU;
+    tmpVecU << vecU[1], vecU[2];
+
+    motionmodel::EgoMotionModel const egoMotionModel;
+
+    Matrix<3, 3> matU = egoMotionModel.getInputNoiseCov(tmpVecX, tmpVecU);
+
+    Matrix<DIM_X, DIM_X> matUout;
+    matUout(0, 0) = matU(0, 0);
+    matUout(0, 1) = matU(0, 1);
+    matUout(0, 4) = matU(0, 2);
+    matUout(1, 0) = matU(1, 0);
+    matUout(1, 1) = matU(1, 1);
+    matUout(1, 4) = matU(1, 2);
+    matUout(4, 0) = matU(2, 0);
+    matUout(4, 1) = matU(2, 1);
+    matUout(4, 4) = matU(2, 1);
+
+    return matUout;
+  }
+
+  virtual Matrix<DIM_X, DIM_X> getJacobianFk(
+      Vector<DIM_X> const& vecX, Vector<DIM_U> const& vecU) const override
+  {
+    Vector<3> tmpVecX;
+    tmpVecX << vecX[0], vecX[1], vecX[4];
+
+    Vector<2> tmpVecU;
+    tmpVecU << vecU[1], vecU[2];
+
+    motionmodel::EgoMotionModel const egoMotionModel;
+
+    Matrix<3, 3> matFk = egoMotionModel.getJacobianFk(tmpVecX, tmpVecU);
+
+    Matrix<DIM_X, DIM_X> matFkout;
+    matFkout(0, 0) = matFk(0, 0);
+    matFkout(0, 1) = matFk(0, 1);
+    matFkout(0, 4) = matFk(0, 2);
+    matFkout(1, 0) = matFk(1, 0);
+    matFkout(1, 1) = matFk(1, 1);
+    matFkout(1, 4) = matFk(1, 2);
+    matFkout(4, 0) = matFk(2, 0);
+    matFkout(4, 1) = matFk(2, 1);
+    matFkout(4, 4) = matFk(2, 1);
+
+    return matFkout;
+  }
+
+  virtual Matrix<DIM_X, DIM_U> getJacobianBk(
+      Vector<DIM_X> const& vecX, Vector<DIM_U> const& vecU) const override
+  {
+    Vector<3> tmpVecX;
+    tmpVecX << vecX[0], vecX[1], vecX[4];
+
+    Vector<2> tmpVecU;
+    tmpVecU << vecU[1], vecU[2];
+
+    motionmodel::EgoMotionModel const egoMotionModel;
+
+    Matrix<3, 2> matBk = egoMotionModel.getJacobianBk(tmpVecX, tmpVecU);
+
+    Matrix<DIM_X, DIM_U> matBkout;
+    matBkout(0, 1) = matBk(0, 0);
+    matBkout(0, 2) = matBk(0, 1);
+    matBkout(1, 1) = matBk(1, 0);
+    matBkout(1, 2) = matBk(1, 1);
+    matBkout(4, 1) = matBk(2, 0);
+    matBkout(4, 2) = matBk(2, 1);
+
+    return matBkout;
+  }
+};
+
+int main()
+{
+  EgoMotionModelAdapter egoMotionModelAdapter;
+
+  Vector<DIM_U> vecU;
+  vecU << 1.0F, 2.0F, 0.01F;
+
+  KalmanFilter<DIM_X, DIM_Z> kf;
+  kf.predictEkf(egoMotionModelAdapter, vecU);
+
+  return 0;
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/ekf_range_sensor/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/ekf_range_sensor/main.cpp
@@ -1,0 +1,74 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/kalman_filter.h"
+#include "kalman_filter/unscented_transform.h"
+#include "types.h"
+
+static constexpr size_t DIM_X{2};
+static constexpr size_t DIM_Z{2};
+
+static kf::KalmanFilter<DIM_X, DIM_Z> kalmanfilter;
+
+kf::Vector<DIM_Z> covertCartesian2Polar(const kf::Vector<DIM_X>& cartesian);
+kf::Matrix<DIM_Z, DIM_Z> calculateJacobianMatrix(const kf::Vector<DIM_X>& vecX);
+void executeCorrectionStep();
+
+int main()
+{
+  executeCorrectionStep();
+
+  return 0;
+}
+
+kf::Vector<DIM_Z> covertCartesian2Polar(const kf::Vector<DIM_X>& cartesian)
+{
+  const kf::Vector<DIM_Z> polar{
+      std::sqrt(cartesian[0] * cartesian[0] + cartesian[1] * cartesian[1]),
+      std::atan2(cartesian[1], cartesian[0])};
+  return polar;
+}
+
+kf::Matrix<DIM_Z, DIM_Z> calculateJacobianMatrix(const kf::Vector<DIM_X>& vecX)
+{
+  const kf::float32_t valX2PlusY2{(vecX[0] * vecX[0]) + (vecX[1] * vecX[1])};
+  const kf::float32_t valSqrtX2PlusY2{std::sqrt(valX2PlusY2)};
+
+  kf::Matrix<DIM_Z, DIM_Z> matHj;
+  matHj << (vecX[0] / valSqrtX2PlusY2), (vecX[1] / valSqrtX2PlusY2),
+      (-vecX[1] / valX2PlusY2), (vecX[0] / valX2PlusY2);
+
+  return matHj;
+}
+
+void executeCorrectionStep()
+{
+  kalmanfilter.vecX() << 10.0F, 5.0F;
+  kalmanfilter.matP() << 0.3F, 0.0F, 0.0F, 0.3F;
+
+  const kf::Vector<DIM_X> measPosCart{10.4F, 5.2F};
+  const kf::Vector<DIM_Z> vecZ{covertCartesian2Polar(measPosCart)};
+
+  kf::Matrix<DIM_Z, DIM_Z> matR;
+  matR << 0.1F, 0.0F, 0.0F, 0.0008F;
+
+  kf::Matrix<DIM_Z, DIM_X> matHj{
+      calculateJacobianMatrix(kalmanfilter.vecX())};  // jacobian matrix Hj
+
+  kalmanfilter.correctEkf(covertCartesian2Polar, vecZ, matR, matHj);
+
+  std::cout << "\ncorrected state vector = \n" << kalmanfilter.vecX() << "\n";
+  std::cout << "\ncorrected state covariance = \n"
+            << kalmanfilter.matP() << "\n";
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/kf_state_estimation/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/kf_state_estimation/main.cpp
@@ -1,0 +1,72 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/kalman_filter.h"
+#include "types.h"
+
+static constexpr size_t DIM_X{2};
+static constexpr size_t DIM_Z{1};
+static constexpr kf::float32_t T{1.0F};
+static constexpr kf::float32_t Q11{0.1F}, Q22{0.1F};
+
+static kf::KalmanFilter<DIM_X, DIM_Z> kalmanfilter;
+
+void executePredictionStep();
+void executeCorrectionStep();
+
+int main()
+{
+  executePredictionStep();
+  executeCorrectionStep();
+
+  return 0;
+}
+
+void executePredictionStep()
+{
+  kalmanfilter.vecX() << 0.0F, 2.0F;
+  kalmanfilter.matP() << 0.1F, 0.0F, 0.0F, 0.1F;
+
+  kf::Matrix<DIM_X, DIM_X> F;  // state transition matrix
+  F << 1.0F, T, 0.0F, 1.0F;
+
+  kf::Matrix<DIM_X, DIM_X> Q;  // process noise covariance
+  Q(0, 0) = (Q11 * T) + (Q22 * (std::pow(T, 3.0F) / 3.0F));
+  Q(0, 1) = Q(1, 0) = Q22 * (std::pow(T, 2.0F) / 2.0F);
+  Q(1, 1) = Q22 * T;
+
+  kalmanfilter.predictLKF(F, Q);  // execute prediction step
+
+  std::cout << "\npredicted state vector = \n" << kalmanfilter.vecX() << "\n";
+  std::cout << "\npredicted state covariance = \n"
+            << kalmanfilter.matP() << "\n";
+}
+
+void executeCorrectionStep()
+{
+  kf::Vector<DIM_Z> vecZ;
+  vecZ << 2.25F;
+
+  kf::Matrix<DIM_Z, DIM_Z> matR;
+  matR << 0.01F;
+
+  kf::Matrix<DIM_Z, DIM_X> matH;
+  matH << 1.0F, 0.0F;
+
+  kalmanfilter.correctLKF(vecZ, matR, matH);
+
+  std::cout << "\ncorrected state vector = \n" << kalmanfilter.vecX() << "\n";
+  std::cout << "\ncorrected state covariance = \n"
+            << kalmanfilter.matP() << "\n";
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/sr_ukf_linear_function/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/sr_ukf_linear_function/main.cpp
@@ -1,0 +1,93 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/square_root_ukf.h"
+#include "types.h"
+
+static constexpr size_t DIM_X{2};
+static constexpr size_t DIM_Z{2};
+
+void runExample1();
+
+kf::Vector<DIM_X> funcF(const kf::Vector<DIM_X>& x)
+{
+  return x;
+}
+
+int main()
+{
+  // example 1
+  runExample1();
+
+  return 0;
+}
+
+void runExample1()
+{
+  std::cout << " Start of Example 1: ===========================" << std::endl;
+
+  // initializations
+  // x0 = np.array([1.0, 2.0])
+  // P0 = np.array([[1.0, 0.5], [0.5, 1.0]])
+  // Q = np.array([[0.5, 0.0], [0.0, 0.5]])
+
+  // z = np.array([1.2, 1.8])
+  // R = np.array([[0.3, 0.0], [0.0, 0.3]])
+
+  kf::Vector<DIM_X> x;
+  x << 1.0F, 2.0F;
+
+  kf::Matrix<DIM_X, DIM_X> P;
+  P << 1.0F, 0.5F, 0.5F, 1.0F;
+
+  kf::Matrix<DIM_X, DIM_X> Q;
+  Q << 0.5F, 0.0F, 0.0F, 0.5F;
+
+  kf::Vector<DIM_Z> z;
+  z << 1.2F, 1.8F;
+
+  kf::Matrix<DIM_Z, DIM_Z> R;
+  R << 0.3F, 0.0F, 0.0F, 0.3F;
+
+  kf::SquareRootUKF<DIM_X, DIM_Z> srUkf;
+  srUkf.initialize(x, P, Q, R);
+
+  srUkf.predictSRUKF(funcF);
+
+  std::cout << "x = \n" << srUkf.vecX() << std::endl;
+  std::cout << "P = \n" << srUkf.matP() << std::endl;
+
+  // Expectation from the python results:
+  // =====================================
+  // x1 =
+  //    [1. 2.]
+  // P1 =
+  //    [[1.5 0.5]
+  //     [0.5 1.5]]
+
+  srUkf.correctSRUKF(funcF, z);
+
+  std::cout << "x = \n" << srUkf.vecX() << std::endl;
+  std::cout << "P = \n" << srUkf.matP() << std::endl;
+
+  // Expectations from the python results:
+  // ======================================
+  // x =
+  //     [1.15385 1.84615]
+  // P =
+  //     [[ 0.24582 0.01505 ]
+  //      [ 0.01505 0.24582 ]]
+
+  std::cout << " End of Example 1: ===========================" << std::endl;
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/test_least_squares/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/test_least_squares/main.cpp
@@ -1,0 +1,101 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "types.h"
+#include "util.h"
+
+void runExample1();
+void runExample2();
+void runExample3();
+void runExample4();
+
+int main()
+{
+  runExample1();
+  runExample2();
+  runExample3();
+  runExample4();
+
+  return 0;
+}
+
+void runExample1()
+{
+  std::cout << " Start of Example 1: ===========================" << std::endl;
+
+  kf::Matrix<3, 3> A;
+  A << 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 1.0, 4.0, 3.0;
+
+  kf::Matrix<2, 3> B;
+  B << 5.0, 6.0, 7.0, 8.0, 9.0, 10.0;
+
+  kf::util::JointRows<3, 2, 3> jmat(A, B);
+  auto AB = jmat.jointMatrix();
+
+  std::cout << "Joint Rows: AB = \n" << AB << std::endl;
+
+  std::cout << " End of Example 1: ===========================" << std::endl;
+}
+
+void runExample2()
+{
+  std::cout << " Start of Example 2: ===========================" << std::endl;
+
+  kf::Matrix<3, 3> A;
+  A << 3.0, 2.0, 1.0, 2.0, 3.0, 4.0, 1.0, 4.0, 3.0;
+
+  kf::Matrix<3, 2> B;
+  B << 5.0, 6.0, 7.0, 8.0, 9.0, 10.0;
+
+  kf::util::JointCols<3, 3, 2> jmat(A, B);
+  auto AB = jmat.jointMatrix();
+
+  std::cout << "Joint Columns: AB = \n" << AB << std::endl;
+
+  std::cout << " End of Example 2: ===========================" << std::endl;
+}
+
+void runExample3()
+{
+  std::cout << " Start of Example 2: ===========================" << std::endl;
+
+  kf::Matrix<3, 3> A;
+  A << 1.0, -2.0, 1.0, 0.0, 1.0, 6.0, 0.0, 0.0, 1.0;
+
+  kf::Matrix<3, 1> b;
+  b << 4.0, -1.0, 2.0;
+
+  auto x = kf::util::backwardSubstitute<3, 1>(A, b);
+
+  std::cout << "Backward Substitution: x = \n" << x << std::endl;
+
+  std::cout << " End of Example 2: ===========================" << std::endl;
+}
+
+void runExample4()
+{
+  std::cout << " Start of Example 2: ===========================" << std::endl;
+
+  kf::Matrix<3, 3> A;
+  A << 1.0, 0.0, 0.0, -2.0, 1.0, 0.0, 1.0, 6.0, 1.0;
+
+  kf::Matrix<3, 1> b;
+  b << 4.0, -1.0, 2.0;
+
+  auto x = kf::util::forwardSubstitute<3, 1>(A, b);
+
+  std::cout << "Forward Substitution: x = \n" << x << std::endl;
+
+  std::cout << " End of Example 2: ===========================" << std::endl;
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/ukf_range_sensor/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/ukf_range_sensor/main.cpp
@@ -1,0 +1,115 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/unscented_kalman_filter.h"
+#include "types.h"
+
+static constexpr size_t DIM_X{4};
+static constexpr size_t DIM_V{4};
+static constexpr size_t DIM_Z{2};
+static constexpr size_t DIM_N{2};
+
+void runExample1();
+
+kf::Vector<DIM_X> funcF(const kf::Vector<DIM_X>& x, const kf::Vector<DIM_V>& v)
+{
+  kf::Vector<DIM_X> y;
+  y[0] = x[0] + x[2] + v[0];
+  y[1] = x[1] + x[3] + v[1];
+  y[2] = x[2] + v[2];
+  y[3] = x[3] + v[3];
+  return y;
+}
+
+kf::Vector<DIM_Z> funcH(const kf::Vector<DIM_X>& x, const kf::Vector<DIM_N>& n)
+{
+  kf::Vector<DIM_Z> y;
+
+  kf::float32_t px{x[0] + n[0]};
+  kf::float32_t py{x[1] + n[1]};
+
+  y[0] = std::sqrt((px * px) + (py * py));
+  y[1] = std::atan(py / (px + std::numeric_limits<kf::float32_t>::epsilon()));
+  return y;
+}
+
+int main()
+{
+  // example 1
+  runExample1();
+
+  return 0;
+}
+
+void runExample1()
+{
+  std::cout << " Start of Example 1: ===========================" << std::endl;
+
+  kf::Vector<DIM_X> x;
+  x << 2.0F, 1.0F, 0.0F, 0.0F;
+
+  kf::Matrix<DIM_X, DIM_X> P;
+  P << 0.01F, 0.0F, 0.0F, 0.0F, 0.0F, 0.01F, 0.0F, 0.0F, 0.0F, 0.0F, 0.05F,
+      0.0F, 0.0F, 0.0F, 0.0F, 0.05F;
+
+  kf::Matrix<DIM_V, DIM_V> Q;
+  Q << 0.05F, 0.0F, 0.0F, 0.0F, 0.0F, 0.05F, 0.0F, 0.0F, 0.0F, 0.0F, 0.1F, 0.0F,
+      0.0F, 0.0F, 0.0F, 0.1F;
+
+  kf::Matrix<DIM_N, DIM_N> R;
+  R << 0.01F, 0.0F, 0.0F, 0.01F;
+
+  kf::Vector<DIM_Z> z;
+  z << 2.5F, 0.05F;
+
+  kf::UnscentedKalmanFilter<DIM_X, DIM_Z, DIM_V, DIM_N> ukf;
+
+  ukf.vecX() = x;
+  ukf.matP() = P;
+
+  ukf.setCovarianceQ(Q);
+  ukf.setCovarianceR(R);
+
+  ukf.predictUKF(funcF);
+
+  std::cout << "x = \n" << ukf.vecX() << std::endl;
+  std::cout << "P = \n" << ukf.matP() << std::endl;
+
+  // Expectation from the python results:
+  // =====================================
+  // x =
+  //     [2.0 1.0 0.0 0.0]
+  // P =
+  //     [[0.11  0.00  0.05  0.00]
+  //      [0.00  0.11  0.00  0.05]
+  //      [0.05  0.00  0.15  0.00]
+  //      [0.00  0.05  0.00  0.15]]
+
+  ukf.correctUKF(funcH, z);
+
+  std::cout << "x = \n" << ukf.vecX() << std::endl;
+  std::cout << "P = \n" << ukf.matP() << std::endl;
+
+  // Expectations from the python results:
+  // ======================================
+  // x =
+  //     [ 2.554  0.356  0.252 -0.293]
+  // P =
+  //     [[ 0.01  -0.001  0.005 -0.    ]
+  //      [-0.001  0.01 - 0.     0.005 ]
+  //      [ 0.005 - 0.     0.129 - 0.  ]
+  //      [-0.     0.005 - 0.     0.129]]
+
+  std::cout << " End of Example 1: ===========================" << std::endl;
+}

--- a/AtReconstruction/AtFitter/OpenKF/examples/unscented_transform/main.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/examples/unscented_transform/main.cpp
@@ -1,0 +1,99 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file main.cpp
+///
+
+#include <iostream>
+#include <stdint.h>
+
+#include "kalman_filter/kalman_filter.h"
+#include "kalman_filter/unscented_transform.h"
+#include "types.h"
+
+static constexpr size_t DIM_1{1};
+static constexpr size_t DIM_2{2};
+
+void runExample1();
+void runExample2();
+
+kf::Vector<DIM_1> function1(const kf::Vector<DIM_1>& x)
+{
+  kf::Vector<DIM_1> y;
+  y[0] = x[0] * x[0];
+  return y;
+}
+
+kf::Vector<DIM_2> function2(const kf::Vector<DIM_2>& x)
+{
+  kf::Vector<DIM_2> y;
+  y[0] = x[0] * x[0];
+  y[1] = x[1] * x[1];
+  return y;
+}
+
+int main()
+{
+  // example 1
+  runExample1();
+
+  // example 2
+  runExample2();
+
+  return 0;
+}
+
+void runExample1()
+{
+  std::cout << " Start of Example 1: ===========================" << std::endl;
+
+  kf::Vector<DIM_1> x;
+  x << 0.0F;
+
+  kf::Matrix<DIM_1, DIM_1> P;
+  P << 0.5F;
+
+  kf::UnscentedTransform<DIM_1> UT;
+  UT.compute(x, P, 0.0F);
+
+  kf::Vector<DIM_1> vecY;
+  kf::Matrix<DIM_1, DIM_1> matPyy;
+
+  UT.transform(function1, vecY, matPyy);
+
+  UT.showSummary();
+  std::cout << "vecY: \n" << vecY << "\n";
+  std::cout << "matPyy: \n" << matPyy << "\n";
+
+  std::cout << " End of Example 1: ===========================" << std::endl;
+}
+
+void runExample2()
+{
+  std::cout << " Start of Example 2: ===========================" << std::endl;
+
+  kf::Vector<DIM_2> x;
+  x << 2.0F, 1.0F;
+
+  kf::Matrix<DIM_2, DIM_2> P;
+  P << 0.1F, 0.0F, 0.0F, 0.1F;
+
+  kf::UnscentedTransform<DIM_2> UT;
+  UT.compute(x, P, 0.0F);
+
+  kf::Vector<DIM_2> vecY;
+  kf::Matrix<DIM_2, DIM_2> matPyy;
+
+  UT.transform(function2, vecY, matPyy);
+
+  UT.showSummary();
+  std::cout << "vecY: \n" << vecY << "\n";
+  std::cout << "matPyy: \n" << matPyy << "\n";
+
+  std::cout << " End of Example 2: ===========================" << std::endl;
+}

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/kalman_filter.h
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/kalman_filter.h
@@ -1,0 +1,98 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file kalman_filter.h
+///
+
+#ifndef KALMAN_FILTER_LIB_H
+#define KALMAN_FILTER_LIB_H
+
+#include "kf_util.h"
+#include "types.h"
+
+namespace kf {
+template <int32_t DIM_X, int32_t DIM_Z>
+class KalmanFilter {
+public:
+   KalmanFilter() {}
+
+   ~KalmanFilter() {}
+
+   virtual Vector<DIM_X> &vecX() { return m_vecX; }
+   virtual const Vector<DIM_X> &vecX() const { return m_vecX; }
+
+   virtual Matrix<DIM_X, DIM_X> &matP() { return m_matP; }
+   virtual const Matrix<DIM_X, DIM_X> &matP() const { return m_matP; }
+
+   ///
+   /// @brief predict state with a linear process model.
+   /// @param matF state transition matrix
+   /// @param matQ process noise covariance matrix
+   ///
+   void predictLKF(const Matrix<DIM_X, DIM_X> &matF, const Matrix<DIM_X, DIM_X> &matQ)
+   {
+      m_vecX = matF * m_vecX;
+      m_matP = matF * m_matP * matF.transpose() + matQ;
+   }
+
+   ///
+   /// @brief correct state of with a linear measurement model.
+   /// @param matZ measurement vector
+   /// @param matR measurement noise covariance matrix
+   /// @param matH measurement transition matrix (measurement model)
+   ///
+   void correctLKF(const Vector<DIM_Z> &vecZ, const Matrix<DIM_Z, DIM_Z> &matR, const Matrix<DIM_Z, DIM_X> &matH)
+   {
+      const Matrix<DIM_X, DIM_X> matI{Matrix<DIM_X, DIM_X>::Identity()};             // Identity matrix
+      const Matrix<DIM_Z, DIM_Z> matSk{matH * m_matP * matH.transpose() + matR};     // Innovation covariance
+      const Matrix<DIM_X, DIM_Z> matKk{m_matP * matH.transpose() * matSk.inverse()}; // Kalman Gain
+
+      m_vecX = m_vecX + matKk * (vecZ - (matH * m_vecX));
+      m_matP = (matI - matKk * matH) * m_matP;
+   }
+
+   ///
+   /// @brief predict state with a linear process model.
+   /// @param predictionModel prediction model function callback
+   /// @param matJacobF state jacobian matrix
+   /// @param matQ process noise covariance matrix
+   ///
+   template <typename PredictionModelCallback>
+   void predictEkf(PredictionModelCallback predictionModelFunc, const Matrix<DIM_X, DIM_X> &matJacobF,
+                   const Matrix<DIM_X, DIM_X> &matQ)
+   {
+      m_vecX = predictionModelFunc(m_vecX);
+      m_matP = matJacobF * m_matP * matJacobF.transpose() + matQ;
+   }
+
+   ///
+   /// @brief correct state of with a linear measurement model.
+   /// @param measurementModel measurement model function callback
+   /// @param matZ measurement vector
+   /// @param matR measurement noise covariance matrix
+   /// @param matJcobH measurement jacobian matrix
+   ///
+   template <typename MeasurementModelCallback>
+   void correctEkf(MeasurementModelCallback measurementModelFunc, const Vector<DIM_Z> &vecZ,
+                   const Matrix<DIM_Z, DIM_Z> &matR, const Matrix<DIM_Z, DIM_X> &matJcobH)
+   {
+      const Matrix<DIM_X, DIM_X> matI{Matrix<DIM_X, DIM_X>::Identity()};                 // Identity matrix
+      const Matrix<DIM_Z, DIM_Z> matSk{matJcobH * m_matP * matJcobH.transpose() + matR}; // Innovation covariance
+      const Matrix<DIM_X, DIM_Z> matKk{m_matP * matJcobH.transpose() * matSk.inverse()}; // Kalman Gain
+
+      m_vecX = m_vecX + matKk * (vecZ - measurementModelFunc(m_vecX));
+      m_matP = (matI - matKk * matJcobH) * m_matP;
+   }
+
+protected:
+   Vector<DIM_X> m_vecX{Vector<DIM_X>::Zero()};               /// @brief estimated state vector
+   Matrix<DIM_X, DIM_X> m_matP{Matrix<DIM_X, DIM_X>::Zero()}; /// @brief state covariance matrix
+};
+} // namespace kf
+
+#endif // KALMAN_FILTER_LIB_H

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/kalman_filter_test.cxx
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/kalman_filter_test.cxx
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include "kalman_filter/kalman_filter.h"
+
+class KalmanFilterTest : public testing::Test {
+public:
+   virtual void SetUp() override {}
+   virtual void TearDown() override {}
+
+   static constexpr float FLOAT_EPSILON{0.00001F};
+
+   static constexpr int32_t DIM_X_LKF{2};
+   static constexpr int32_t DIM_Z_LKF{1};
+   static constexpr int32_t DIM_X_EKF{2};
+   static constexpr int32_t DIM_Z_EKF{2};
+   static constexpr kf::float32_t Q11{0.1F}, Q22{0.1F};
+
+   kf::KalmanFilter<DIM_X_LKF, DIM_Z_LKF> m_lkf;
+   kf::KalmanFilter<DIM_X_EKF, DIM_Z_EKF> m_ekf;
+
+   static kf::Vector<DIM_Z_EKF> covertCartesian2Polar(const kf::Vector<DIM_X_EKF> &cartesian)
+   {
+      kf::Vector<DIM_Z_EKF> polar;
+      polar[0] = std::sqrt(cartesian[0] * cartesian[0] + cartesian[1] * cartesian[1]);
+      polar[1] = std::atan2(cartesian[1], cartesian[0]);
+      return polar;
+   }
+
+   static kf::Matrix<DIM_Z_EKF, DIM_Z_EKF> calculateJacobianMatrix(const kf::Vector<DIM_X_EKF> &vecX)
+   {
+      const kf::float32_t valX2PlusY2{(vecX[0] * vecX[0]) + (vecX[1] * vecX[1])};
+      const kf::float32_t valSqrtX2PlusY2{std::sqrt(valX2PlusY2)};
+
+      kf::Matrix<DIM_Z_EKF, DIM_Z_EKF> matHj;
+      matHj << (vecX[0] / valSqrtX2PlusY2), (vecX[1] / valSqrtX2PlusY2), (-vecX[1] / valX2PlusY2),
+         (vecX[0] / valX2PlusY2);
+
+      return matHj;
+   }
+};
+TEST_F(KalmanFilterTest, test_predictLKF)
+{
+   static constexpr float SAMPLE_TIME_SEC{1.0F};
+
+   m_lkf.vecX() << 0.0F, 2.0F;
+   m_lkf.matP() << 0.1F, 0.0F, 0.0F, 0.1F;
+
+   kf::Matrix<DIM_X_LKF, DIM_X_LKF> F; // state transition matrix
+   F << 1.0F, SAMPLE_TIME_SEC, 0.0F, 1.0F;
+
+   kf::Matrix<DIM_X_LKF, DIM_X_LKF> Q; // process noise covariance
+   Q(0, 0) = (Q11 * SAMPLE_TIME_SEC) + (Q22 * (std::pow(SAMPLE_TIME_SEC, 3.0F) / 3.0F));
+   Q(0, 1) = Q(1, 0) = Q22 * (std::pow(SAMPLE_TIME_SEC, 2.0F) / 2.0F);
+   Q(1, 1) = Q22 * SAMPLE_TIME_SEC;
+
+   m_lkf.predictLKF(F, Q); // execute prediction step
+
+   ASSERT_NEAR(m_lkf.vecX()(0), 2.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.vecX()(1), 2.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_lkf.matP()(0), 0.33333F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(1), 0.15F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(2), 0.15F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(3), 0.2F, FLOAT_EPSILON);
+}
+
+TEST_F(KalmanFilterTest, test_correctLKF)
+{
+   m_lkf.vecX() << 2.0F, 2.0F;
+   m_lkf.matP() << 0.33333F, 0.15F, 0.15F, 0.2F;
+
+   kf::Vector<DIM_Z_LKF> vecZ;
+   vecZ << 2.25F;
+
+   kf::Matrix<DIM_Z_LKF, DIM_Z_LKF> matR;
+   matR << 0.01F;
+
+   kf::Matrix<DIM_Z_LKF, DIM_X_LKF> matH;
+   matH << 1.0F, 0.0F;
+
+   m_lkf.correctLKF(vecZ, matR, matH);
+
+   ASSERT_NEAR(m_lkf.vecX()(0), 2.24272F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.vecX()(1), 2.10922F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_lkf.matP()(0), 0.00970874F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(1), 0.00436893F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(2), 0.00436893F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_lkf.matP()(3), 0.134466F, FLOAT_EPSILON);
+}
+
+TEST_F(KalmanFilterTest, test_correctEKF)
+{
+   m_ekf.vecX() << 10.0F, 5.0F;
+   m_ekf.matP() << 0.3F, 0.0F, 0.0F, 0.3F;
+
+   const kf::Vector<DIM_X_EKF> measPosCart{10.4F, 5.2F};
+   const kf::Vector<DIM_Z_EKF> vecZ{covertCartesian2Polar(measPosCart)};
+
+   kf::Matrix<DIM_Z_EKF, DIM_Z_EKF> matR;
+   matR << 0.1F, 0.0F, 0.0F, 0.0008F;
+
+   kf::Matrix<DIM_Z_EKF, DIM_X_EKF> matHj{calculateJacobianMatrix(m_ekf.vecX())}; // jacobian matrix Hj
+
+   m_ekf.correctEkf(covertCartesian2Polar, vecZ, matR, matHj);
+
+   ASSERT_NEAR(m_ekf.vecX()(0), 10.3F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ekf.vecX()(1), 5.15F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ekf.matP()(0), 0.075F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ekf.matP()(1), -1.78814e-08F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ekf.matP()(2), -1.78814e-08F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ekf.matP()(3), 0.075F, FLOAT_EPSILON);
+}

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/square_root_ukf.h
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/square_root_ukf.h
@@ -1,0 +1,357 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file square_root_ukf.h
+///
+
+#ifndef SQUARE_ROOT_UNSCENTED_KALMAN_FILTER_LIB_H
+#define SQUARE_ROOT_UNSCENTED_KALMAN_FILTER_LIB_H
+
+#include "kalman_filter.h"
+#include "kf_util.h"
+
+namespace kf {
+template <int32_t DIM_X, int32_t DIM_Z>
+class SquareRootUKF : public KalmanFilter<DIM_X, DIM_Z> {
+public:
+   static constexpr int32_t SIGMA_DIM{2 * DIM_X + 1};
+
+   SquareRootUKF() : KalmanFilter<DIM_X, DIM_Z>()
+   {
+      // calculate weights
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_X)};
+      updateWeights(kappa);
+   }
+
+   ~SquareRootUKF() {}
+
+   Matrix<DIM_X, DIM_X> &matP() override { return (m_matP = m_matSk * m_matSk.transpose()); }
+   // const Matrix<DIM_X, DIM_X> & matP() const override { return (m_matP =
+   // m_matSk * m_matSk.transpose()); }
+
+   void initialize(const Vector<DIM_X> &vecX, const Matrix<DIM_X, DIM_X> &matP, const Matrix<DIM_X, DIM_X> &matQ,
+                   const Matrix<DIM_Z, DIM_Z> &matR)
+   {
+      m_vecX = vecX;
+
+      {
+         // cholesky factorization to get matrix Pk square-root
+         Eigen::LLT<Matrix<DIM_X, DIM_X>> lltOfP(matP);
+         m_matSk = lltOfP.matrixL(); // sqrt(P)
+      }
+
+      {
+         // cholesky factorization to get matrix Q square-root
+         Eigen::LLT<Matrix<DIM_X, DIM_X>> lltOfRv(matQ);
+         m_matRv = lltOfRv.matrixL(); // sqrt(Q)
+      }
+
+      {
+         // cholesky factorization to get matrix R square-root
+         Eigen::LLT<Matrix<DIM_Z, DIM_Z>> lltOfRn(matR);
+         m_matRn = lltOfRn.matrixL(); // sqrt(R)
+      }
+   }
+
+   ///
+   /// @brief setting the cholesky factorization of state covariance P.
+   /// @param matP state covariance matrix
+   ///
+   void setCovarianceP(const Matrix<DIM_X, DIM_X> &matP)
+   {
+      // cholesky factorization to get matrix Q square-root
+      Eigen::LLT<Matrix<DIM_X, DIM_X>> lltOfPk(matP);
+      m_matSk = lltOfPk.matrixL();
+   }
+
+   ///
+   /// @brief setting the cholesky factorization of process noise covariance Q.
+   /// @param matQ process noise covariance matrix
+   ///
+   void setCovarianceQ(const Matrix<DIM_X, DIM_X> &matQ)
+   {
+      // cholesky factorization to get matrix Q square-root
+      Eigen::LLT<Matrix<DIM_X, DIM_X>> lltOfRv(matQ);
+      m_matRv = lltOfRv.matrixL();
+   }
+
+   ///
+   /// @brief setting the cholesky factorization of measurement noise covariance
+   /// R.
+   /// @param matR process noise covariance matrix
+   ///
+   void setCovarianceR(const Matrix<DIM_Z, DIM_Z> &matR)
+   {
+      // cholesky factorization to get matrix R square-root
+      Eigen::LLT<Matrix<DIM_Z, DIM_Z>> lltOfRn(matR);
+      m_matRn = lltOfRn.matrixL(); // sqrt(R)
+   }
+
+   ///
+   /// @brief state prediction step of the unscented Kalman filter (UKF).
+   /// @param predictionModelFunc callback to the prediction/process model
+   /// function
+   ///
+   template <typename PredictionModelCallback>
+   void predictSRUKF(PredictionModelCallback predictionModelFunc)
+   {
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_X)};
+
+      // x_sigmas = self.sigma_points(self.x, self.S)
+      Matrix<DIM_X, SIGMA_DIM> matSigmaX{calculateSigmaPoints(m_vecX, m_matSk, kappa)};
+
+      // y_sigmas = np.zeros((self.dim_x, self.n_sigma))
+      // for i in range(self.n_sigma):
+      //     y_sigmas[:, i] = f(x_sigmas[:, i])
+      for (int32_t i{0}; i < SIGMA_DIM; ++i) {
+         const Vector<DIM_X> Xi{util::getColumnAt<DIM_X, SIGMA_DIM>(i, matSigmaX)};
+         const Vector<DIM_X> Yi{predictionModelFunc(Xi)}; // y = f(x)
+
+         util::copyToColumn<DIM_X, SIGMA_DIM>(i, matSigmaX, Yi); // Y[:, i] = y
+      }
+
+      // calculate weighted mean of the predicted state
+      calculateWeightedMean<DIM_X>(matSigmaX, m_vecX);
+
+      // update of cholesky factorized state covariance Sk
+      m_matSk = updatePredictedCovariance<DIM_X>(matSigmaX, m_vecX, m_matRv);
+   }
+
+   ///
+   /// @brief measurement correction step of the unscented Kalman filter (UKF).
+   /// @param measurementModelFunc callback to the measurement model function
+   /// @param vecZ actual measurement vector.
+   ///
+   template <typename MeasurementModelCallback>
+   void correctSRUKF(MeasurementModelCallback measurementModelFunc, const Vector<DIM_Z> &vecZ)
+   {
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_X)};
+
+      // x_sigmas = self.sigma_points(self.x, self.S)
+      Matrix<DIM_X, SIGMA_DIM> matSigmaX{calculateSigmaPoints(m_vecX, m_matSk, kappa)};
+
+      // y_sigmas = np.zeros((self.dim_x, self.n_sigma))
+      // for i in range(self.n_sigma):
+      //     y_sigmas[:, i] = f(x_sigmas[:, i])
+      Matrix<DIM_Z, SIGMA_DIM> matSigmaY;
+
+      for (int32_t i{0}; i < SIGMA_DIM; ++i) {
+         const Vector<DIM_X> Xi{util::getColumnAt<DIM_X, SIGMA_DIM>(i, matSigmaX)};
+         const Vector<DIM_Z> Yi{measurementModelFunc(Xi)}; // y = f(x)
+
+         util::copyToColumn<DIM_Z, SIGMA_DIM>(i, matSigmaY, Yi); // Y[:, i] = y
+      }
+
+      // calculate weighted mean of the predicted state
+      Vector<DIM_Z> vecY;
+      calculateWeightedMean<DIM_Z>(matSigmaY, vecY);
+
+      // update of cholesky factorized state covariance Sk
+      const Matrix<DIM_Z, DIM_Z> matSy{updatePredictedCovariance<DIM_Z>(matSigmaY, vecY, m_matRn)};
+
+      // cross-correlation
+      const Matrix<DIM_X, DIM_Z> matPxy{calculateCrossCorrelation(matSigmaX, m_vecX, matSigmaY, vecY)};
+
+      // Kalman Gain
+      Matrix<DIM_X, DIM_Z> matKk;
+      matKk = util::forwardSubstitute<DIM_X, DIM_Z>(matSy, matPxy);
+      matKk = util::backwardSubstitute<DIM_X, DIM_Z>(matSy.transpose(), matKk);
+
+      // state vector correction
+      m_vecX += matKk * (vecZ - vecY);
+
+      // state covariance correction
+      const Matrix<DIM_X, DIM_Z> matU{matKk * matSy};
+      m_matSk = util::cholupdate<DIM_X, DIM_X, DIM_Z>(m_matSk, matU, -1.0);
+   }
+
+private:
+   using KalmanFilter<DIM_X, DIM_Z>::m_vecX; // from Base KalmanFilter class
+   using KalmanFilter<DIM_X, DIM_Z>::m_matP; // from Base KalmanFilter class
+
+   float32_t m_weight0; /// @brief unscented transform weight 0 for mean
+   float32_t m_weighti; /// @brief unscented transform weight i for none mean samples
+
+   Matrix<DIM_X, DIM_X> m_matSk{Matrix<DIM_X, DIM_X>::Zero()}; /// @brief augmented state covariance (incl.
+                                                               /// process and measurement noise covariances)
+   Matrix<DIM_X, DIM_X> m_matRv{Matrix<DIM_X, DIM_X>::Zero()}; /// @brief augmented state covariance (incl.
+                                                               /// process and measurement noise covariances)
+   Matrix<DIM_Z, DIM_Z> m_matRn{Matrix<DIM_Z, DIM_Z>::Zero()}; /// @brief augmented state covariance (incl.
+                                                               /// process and measurement noise covariances)
+
+   ///
+   /// @brief algorithm to calculate the weights used to draw the sigma points
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   void updateWeights(float32_t kappa)
+   {
+      static_assert(DIM_X > 0, "DIM_X is Zero which leads to numerical issue.");
+
+      const float32_t denoTerm{kappa + static_cast<float32_t>(DIM_X)};
+
+      m_weight0 = kappa / denoTerm;
+      m_weighti = 0.5F / denoTerm;
+   }
+
+   ///
+   /// @brief algorithm to calculate the deterministic sigma points for
+   /// the unscented transformation
+   ///
+   /// @param vecXk mean of the normally distributed state
+   /// @param matSk covariance of the normally distributed state
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   Matrix<DIM_X, SIGMA_DIM>
+   calculateSigmaPoints(const Vector<DIM_X> &vecXk, const Matrix<DIM_X, DIM_X> &matSk, const float32_t kappa)
+   {
+      const Matrix<DIM_X, DIM_X> matS{matSk * std::sqrt(DIM_X + kappa)}; // sqrt(n + \kappa) * Sk
+
+      Matrix<DIM_X, SIGMA_DIM> sigmaX;
+
+      // X_0 = \bar{xa}
+      util::copyToColumn<DIM_X, SIGMA_DIM>(0, sigmaX, vecXk);
+
+      for (int32_t i{0}; i < DIM_X; ++i) {
+         const int32_t IDX_1{i + 1};
+         const int32_t IDX_2{i + DIM_X + 1};
+
+         util::copyToColumn<DIM_X, SIGMA_DIM>(IDX_1, sigmaX, vecXk);
+         util::copyToColumn<DIM_X, SIGMA_DIM>(IDX_2, sigmaX, vecXk);
+
+         const Vector<DIM_X> vecShiftTerm{util::getColumnAt<DIM_X, DIM_X>(i, matS)};
+
+         util::addColumnFrom<DIM_X, SIGMA_DIM>(IDX_1, sigmaX,
+                                               vecShiftTerm); // X_i     = \bar{x} + sqrt(n + \kappa) * Sk
+         util::subColumnFrom<DIM_X, SIGMA_DIM>(IDX_2, sigmaX,
+                                               vecShiftTerm); // X_{i+n} = \bar{x} - sqrt(n + \kappa) * Sk
+      }
+
+      return sigmaX;
+   }
+
+   ///
+   /// @brief calculate the weighted mean and covariance given a set of sigma
+   /// points
+   /// @param sigmaX matrix of sigma points where each column contain single
+   /// sigma point
+   /// @param vecX output weighted mean
+   ///
+   template <int32_t DIM>
+   void calculateWeightedMean(const Matrix<DIM, SIGMA_DIM> &sigmaX, Vector<DIM> &vecX)
+   {
+      // 1. calculate mean: \bar{y} = \sum_{i_0}^{2n} W[0, i] Y[:, i]
+      vecX = m_weight0 * util::getColumnAt<DIM, SIGMA_DIM>(0, sigmaX);
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         vecX += m_weighti * util::getColumnAt<DIM, SIGMA_DIM>(i, sigmaX); // y += W[0, i] Y[:, i]
+      }
+   }
+
+   ///
+   /// @brief calculate the cross-correlation given two sets sigma points X and Y
+   /// and their means x and y
+   /// @param sigmaX first matrix of sigma points where each column contain
+   /// single sigma point
+   /// @param vecX mean of the first set of sigma points
+   /// @param sigmaY second matrix of sigma points where each column contain
+   /// single sigma point
+   /// @param vecY mean of the second set of sigma points
+   /// @return matPxy, the cross-correlation matrix
+   ///
+   Matrix<DIM_X, DIM_Z> calculateCrossCorrelation(const Matrix<DIM_X, SIGMA_DIM> &sigmaX, const Vector<DIM_X> &vecX,
+                                                  const Matrix<DIM_Z, SIGMA_DIM> &sigmaY, const Vector<DIM_Z> &vecY)
+   {
+      Vector<DIM_X> devXi{util::getColumnAt<DIM_X, SIGMA_DIM>(0, sigmaX) - vecX}; // X[:, 0] - \bar{ x }
+      Vector<DIM_Z> devYi{util::getColumnAt<DIM_Z, SIGMA_DIM>(0, sigmaY) - vecY}; // Y[:, 0] - \bar{ y }
+
+      // P_0 = W[0, 0] (X[:, 0] - \bar{x}) (Y[:, 0] - \bar{y})^T
+      Matrix<DIM_X, DIM_Z> matPxy{m_weight0 * (devXi * devYi.transpose())};
+
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         devXi = util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaX) - vecX; // X[:, i] - \bar{x}
+         devYi = util::getColumnAt<DIM_Z, SIGMA_DIM>(i, sigmaY) - vecY; // Y[:, i] - \bar{y}
+
+         matPxy += m_weighti * (devXi * devYi.transpose()); // y += W[0, i] (Y[:, i] -
+                                                            // \bar{y}) (Y[:, i] - \bar{y})^T
+      }
+
+      return matPxy;
+   }
+
+   template <int32_t DIM>
+   Matrix<DIM, DIM> updatePredictedCovariance(const Matrix<DIM, SIGMA_DIM> &matSigmaX, const Vector<DIM> &meanX,
+                                              const Matrix<DIM, DIM> &matU)
+   {
+      constexpr int32_t DIM_ROW{SIGMA_DIM + DIM - 1};
+      constexpr int32_t DIM_COL{DIM};
+
+      // build compound matrix for square - root covariance update
+      // sigmas_X[:, 0] is not added because W0 could be zero which will lead
+      // to undefined outcome from sqrt(W0).
+      Matrix<DIM_ROW, DIM_COL> matC{buildCompoundMatrix(matSigmaX, meanX, matU)};
+
+      // calculate square - root covariance S using QR decomposition of compound
+      // matrix C including the process noise covariance
+      // _, S_minus = np.linalg.qr(C)
+      Eigen::HouseholderQR<Matrix<DIM_ROW, DIM_COL>> qr(matC);
+
+      Matrix<DIM_ROW, DIM_COL> qrMatrixUpper{qr.matrixQR()};
+      qrMatrixUpper = util::getUpperTriangulerView<DIM_ROW, DIM_COL>(qrMatrixUpper);
+
+      // get the upper triangular matrix from the factorization
+      // might need to reimplement QR factorization it as it seems to use dynamic
+      // memory allocation Matrix<DIM, DIM> matR{
+      //     util::getBlock<DIM_ROW, DIM_COL, DIM, DIM>(
+      //         qr.matrixQR().triangularView<Eigen::Upper>(), 0, 0)
+      // };
+
+      Matrix<DIM, DIM> matR{util::getBlock<DIM_ROW, DIM_COL, DIM, DIM>(qrMatrixUpper, 0, 0)};
+
+      // Rank - 1 cholesky update
+      // x_dev = sigmas_X[:, 0] - x_minus
+      // x_dev = np.reshape(x_dev, [-1, 1])
+      // S_minus = cholupdate(S_minus.T, x_dev, self.W0)
+      // TODO: implement cholupdate, the one from Eigen is not straight forward to
+      // use
+      Vector<DIM> devX0 = util::getColumnAt<DIM, SIGMA_DIM>(0, matSigmaX) - meanX;
+      matR = util::cholupdate<DIM, DIM, 1>(matR.transpose(), devX0, m_weight0);
+
+      return matR;
+   }
+
+   Matrix<SIGMA_DIM + DIM_X - 1, DIM_X> buildCompoundMatrix(const Matrix<DIM_X, SIGMA_DIM> &matSigmaX,
+                                                            const Vector<DIM_X> &meanX,
+                                                            const Matrix<DIM_X, DIM_X> &matU)
+   {
+      // build compoint/joint matrix for square-root covariance update
+
+      constexpr int32_t DIM_ROW{SIGMA_DIM + DIM_X - 1};
+      constexpr int32_t DIM_COL{DIM_X};
+
+      Matrix<DIM_ROW, DIM_COL> matC;
+
+      // C = (sigmas_X[:, 1 : ].T - x_minus) * np.sqrt(self.Wi)
+      const float32_t sqrtWi{std::sqrt(m_weighti)};
+      for (int32_t i{0}; i < DIM_X; ++i) {
+         for (int32_t j{1}; j < SIGMA_DIM; ++j) {
+            matC(j - 1, i) = sqrtWi * (matSigmaX(i, j) - meanX[i]);
+         }
+      }
+
+      // C = np.concatenate((C, self.sqrt_Q.T), axis=0)
+      for (int32_t i{0}; i < DIM_X; ++i) {
+         for (int32_t j{0}; j < DIM_X; ++j) {
+            matC(j + SIGMA_DIM - 1, i) = matU(i, j);
+         }
+      }
+
+      return matC;
+   }
+};
+} // namespace kf
+
+#endif // UNSCENTED_KALMAN_FILTER_LIB_H

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/square_root_ukf_test.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/square_root_ukf_test.cpp
@@ -1,0 +1,83 @@
+#include "gtest/gtest.h"
+#include "kalman_filter/square_root_ukf.h"
+
+class SquareRootUnscentedKalmanFilterTest : public testing::Test {
+public:
+   virtual void SetUp() override {}
+   virtual void TearDown() override {}
+
+   static constexpr float FLOAT_EPSILON{0.001F};
+
+   static constexpr size_t DIM_X{2};
+   static constexpr size_t DIM_Z{2};
+
+   kf::SquareRootUKF<DIM_X, DIM_Z> m_srUkf;
+
+   static kf::Vector<DIM_X> funcF(const kf::Vector<DIM_X> &x) { return x; }
+};
+
+TEST_F(SquareRootUnscentedKalmanFilterTest, test_SRUKF_Example01)
+{
+   // initializations
+   // x0 = np.array([1.0, 2.0])
+   // P0 = np.array([[1.0, 0.5], [0.5, 1.0]])
+   // Q = np.array([[0.5, 0.0], [0.0, 0.5]])
+
+   // z = np.array([1.2, 1.8])
+   // R = np.array([[0.3, 0.0], [0.0, 0.3]])
+
+   kf::Vector<DIM_X> x;
+   x << 1.0F, 2.0F;
+
+   kf::Matrix<DIM_X, DIM_X> P;
+   P << 1.0F, 0.5F, 0.5F, 1.0F;
+
+   kf::Matrix<DIM_X, DIM_X> Q;
+   Q << 0.5F, 0.0F, 0.0F, 0.5F;
+
+   kf::Vector<DIM_Z> z;
+   z << 1.2F, 1.8F;
+
+   kf::Matrix<DIM_Z, DIM_Z> R;
+   R << 0.3F, 0.0F, 0.0F, 0.3F;
+
+   m_srUkf.initialize(x, P, Q, R);
+
+   m_srUkf.predictSRUKF(funcF);
+
+   // Expectation from the python results:
+   // =====================================
+   // x1 =
+   //    [1. 2.]
+   // P1 =
+   //    [[1.5 0.5]
+   //     [0.5 1.5]]
+
+   ASSERT_NEAR(m_srUkf.vecX()[0], 1.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.vecX()[1], 2.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_srUkf.matP()(0, 0), 1.5F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.matP()(0, 1), 0.5F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_srUkf.matP()(1, 0), 0.5F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.matP()(1, 1), 1.5F, FLOAT_EPSILON);
+
+   m_srUkf.correctSRUKF(funcF, z);
+
+   // Expectations from the python results:
+   // ======================================
+   // x =
+   //     [1.15385 1.84615]
+   // P =
+   //     [[ 0.24582 0.01505 ]
+   //      [ 0.01505 0.24582 ]]
+
+   ASSERT_NEAR(m_srUkf.vecX()[0], 1.15385F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.vecX()[1], 1.84615F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_srUkf.matP()(0, 0), 0.24582F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.matP()(0, 1), 0.01505F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_srUkf.matP()(1, 0), 0.01505F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_srUkf.matP()(1, 1), 0.24582F, FLOAT_EPSILON);
+}

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_kalman_filter.h
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_kalman_filter.h
@@ -1,0 +1,333 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file unscented_kalman_filter.h
+///
+
+#ifndef UNSCENTED_KALMAN_FILTER_LIB_H
+#define UNSCENTED_KALMAN_FILTER_LIB_H
+
+#include "kalman_filter.h"
+#include "kf_util.h"
+
+namespace kf {
+template <int32_t DIM_X, int32_t DIM_Z, int32_t DIM_V, int32_t DIM_N>
+class UnscentedKalmanFilter : public KalmanFilter<DIM_X, DIM_Z> {
+public:
+   static constexpr int32_t DIM_A{DIM_X + DIM_V + DIM_N};
+   static constexpr int32_t SIGMA_DIM{2 * DIM_A + 1};
+
+   UnscentedKalmanFilter() : KalmanFilter<DIM_X, DIM_Z>()
+   {
+      // 1. calculate weights
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_A)};
+      updateWeights(kappa);
+   }
+
+   ~UnscentedKalmanFilter() {}
+
+   ///
+   /// @brief adding process noise covariance Q to the augmented state covariance
+   /// matPa in the middle element of the diagonal.
+   ///
+   void setCovarianceQ(const Matrix<DIM_V, DIM_V> &matQ)
+   {
+      const int32_t S_IDX{DIM_X};
+      const int32_t L_IDX{S_IDX + DIM_V};
+
+      for (int32_t i{S_IDX}; i < L_IDX; ++i) {
+         for (int32_t j{S_IDX}; j < L_IDX; ++j) {
+            m_matPa(i, j) = matQ(i - S_IDX, j - S_IDX);
+         }
+      }
+   }
+
+   ///
+   /// @brief adding measurement noise covariance R to the augmented state
+   /// covariance matPa in the third element of the diagonal.
+   ///
+   void setCovarianceR(const Matrix<DIM_N, DIM_N> &matR)
+   {
+      const int32_t S_IDX{DIM_X + DIM_V};
+      const int32_t L_IDX{S_IDX + DIM_N};
+
+      for (int32_t i{S_IDX}; i < L_IDX; ++i) {
+         for (int32_t j{S_IDX}; j < L_IDX; ++j) {
+            m_matPa(i, j) = matR(i - S_IDX, j - S_IDX);
+         }
+      }
+   }
+
+   ///
+   /// @brief adding vecX and matP to the augmented state vector and covariance
+   /// vecXa and matPa
+   ///
+   void updateAugmentedStateAndCovariance()
+   {
+      updateAugmentedVecX();
+      updateAugmentedMatP();
+   }
+
+   ///
+   /// @brief state prediction step of the unscented Kalman filter (UKF).
+   /// @param predictionModelFunc callback to the prediction/process model
+   /// function
+   ///
+   template <typename PredictionModelCallback>
+   void predictUKF(PredictionModelCallback predictionModelFunc)
+   {
+      // self.x_a[:self.dim_x] = x
+      // self.P_a[:self.dim_x, : self.dim_x] = P
+      updateAugmentedStateAndCovariance();
+
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_A)};
+
+      // xa_sigmas = self.sigma_points(self.x_a, self.P_a)
+      Matrix<DIM_A, SIGMA_DIM> matSigmaXa{calculateSigmaPoints(m_vecXa, m_matPa, kappa)};
+
+      // xx_sigmas = xa_sigmas[:self.dim_x, :]
+      // Matrix<DIM_X, SIGMA_DIM> sigmaXx{ matSigmaXa.block<DIM_X, SIGMA_DIM>(0,
+      // 0) };
+      Matrix<DIM_X, SIGMA_DIM> sigmaXx{matSigmaXa.block(0, 0, DIM_X, SIGMA_DIM)};
+
+      // xv_sigmas = xa_sigmas[self.dim_x : self.dim_x + self.dim_v, :]
+      Matrix<DIM_V, SIGMA_DIM> sigmaXv{matSigmaXa.block(DIM_X, 0, DIM_V, SIGMA_DIM)};
+
+      // y_sigmas = np.zeros((self.dim_x, self.n_sigma))
+      // for i in range(self.n_sigma):
+      //     y_sigmas[:, i] = f(xx_sigmas[:, i], xv_sigmas[:, i])
+      for (int32_t i{0}; i < SIGMA_DIM; ++i) {
+         const Vector<DIM_X> sigmaXxi{util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaXx)};
+         const Vector<DIM_V> sigmaXvi{util::getColumnAt<DIM_V, SIGMA_DIM>(i, sigmaXv)};
+
+         const Vector<DIM_X> Yi{predictionModelFunc(sigmaXxi, sigmaXvi)}; // y = f(x)
+
+         util::copyToColumn<DIM_X, SIGMA_DIM>(i, sigmaXx, Yi); // Y[:, i] = y
+      }
+
+      // y, Pyy = self.calculate_mean_and_covariance(y_sigmas)
+      calculateWeightedMeanAndCovariance<DIM_X>(sigmaXx, m_vecX, m_matP);
+
+      //// self.x_a[:self.dim_x] = y
+      //// self.P_a[:self.dim_x, : self.dim_x] = Pyy
+      // updateAugmentedStateAndCovariance();
+   }
+
+   ///
+   /// @brief measurement correction step of the unscented Kalman filter (UKF).
+   /// @param measurementModelFunc callback to the measurement model function
+   /// @param vecZ actual measurement vector.
+   ///
+   template <typename MeasurementModelCallback>
+   void correctUKF(MeasurementModelCallback measurementModelFunc, const Vector<DIM_Z> &vecZ)
+   {
+      // self.x_a[:self.dim_x] = x
+      // self.P_a[:self.dim_x, : self.dim_x] = P
+      updateAugmentedStateAndCovariance();
+
+      const float32_t kappa{static_cast<float32_t>(3 - DIM_A)};
+
+      // xa_sigmas = self.sigma_points(self.x_a, self.P_a)
+      Matrix<DIM_A, SIGMA_DIM> matSigmaXa{calculateSigmaPoints(m_vecXa, m_matPa, kappa)};
+
+      // xx_sigmas = xa_sigmas[:self.dim_x, :]
+      Matrix<DIM_X, SIGMA_DIM> sigmaXx{matSigmaXa.block(0, 0, DIM_X, SIGMA_DIM)};
+
+      // xn_sigmas = xa_sigmas[self.dim_x + self.dim_v :, :]
+      Matrix<DIM_N, SIGMA_DIM> sigmaXn{matSigmaXa.block(DIM_X + DIM_V, 0, DIM_N, SIGMA_DIM)};
+
+      // y_sigmas = np.zeros((self.dim_z, self.n_sigma))
+      // for i in range(self.n_sigma) :
+      //     y_sigmas[:, i] = h(xx_sigmas[:, i], xn_sigmas[:, i])
+      Matrix<DIM_Z, SIGMA_DIM> sigmaY;
+      for (int32_t i{0}; i < SIGMA_DIM; ++i) {
+         const Vector<DIM_X> sigmaXxi{util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaXx)};
+         const Vector<DIM_N> sigmaXni{util::getColumnAt<DIM_N, SIGMA_DIM>(i, sigmaXn)};
+
+         const Vector<DIM_Z> Yi{measurementModelFunc(sigmaXxi, sigmaXni)}; // y = f(x)
+
+         util::copyToColumn<DIM_Z, SIGMA_DIM>(i, sigmaY, Yi); // Y[:, i] = y
+      }
+
+      // y, Pyy = self.calculate_mean_and_covariance(y_sigmas)
+      Vector<DIM_Z> vecY;
+      Matrix<DIM_Z, DIM_Z> matPyy;
+      calculateWeightedMeanAndCovariance<DIM_Z>(sigmaY, vecY, matPyy);
+
+      // TODO: calculate cross correlation
+      const Matrix<DIM_X, DIM_Z> matPxy{calculateCrossCorrelation(sigmaXx, m_vecX, sigmaY, vecY)};
+
+      // kalman gain
+      const Matrix<DIM_X, DIM_Z> matK{matPxy * matPyy.inverse()};
+
+      m_vecX += matK * (vecZ - vecY);
+      m_matP -= matK * matPyy * matK.transpose();
+
+      //// self.x_a[:self.dim_x] = x
+      //// self.P_a[:self.dim_x, : self.dim_x] = P
+      // updateAugmentedStateAndCovariance();
+   }
+
+private:
+   using KalmanFilter<DIM_X, DIM_Z>::m_vecX; // from Base KalmanFilter class
+   using KalmanFilter<DIM_X, DIM_Z>::m_matP; // from Base KalmanFilter class
+
+   float32_t m_weight0; /// @brief unscented transform weight 0 for mean
+   float32_t m_weighti; /// @brief unscented transform weight i for none mean samples
+
+   Vector<DIM_A> m_vecXa{Vector<DIM_A>::Zero()};               /// @brief augmented state vector (incl. process
+                                                               /// and measurement noise means)
+   Matrix<DIM_A, DIM_A> m_matPa{Matrix<DIM_A, DIM_A>::Zero()}; /// @brief augmented state covariance (incl.
+                                                               /// process and measurement noise covariances)
+
+   ///
+   /// @brief add state vector m_vecX to the augment state vector m_vecXa
+   ///
+   void updateAugmentedVecX()
+   {
+      for (int32_t i{0}; i < DIM_X; ++i) {
+         m_vecXa[i] = m_vecX[i];
+      }
+   }
+
+   ///
+   /// @brief add covariance matrix m_matP to the augment covariance m_matPa
+   ///
+   void updateAugmentedMatP()
+   {
+      for (int32_t i{0}; i < DIM_X; ++i) {
+         for (int32_t j{0}; j < DIM_X; ++j) {
+            m_matPa(i, j) = m_matP(i, j);
+         }
+      }
+   }
+
+   ///
+   /// @brief algorithm to calculate the weights used to draw the sigma points
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   void updateWeights(float32_t kappa)
+   {
+      static_assert(DIM_A > 0, "DIM_A is Zero which leads to numerical issue.");
+
+      const float32_t denoTerm{kappa + static_cast<float32_t>(DIM_A)};
+
+      m_weight0 = kappa / denoTerm;
+      m_weighti = 0.5F / denoTerm;
+   }
+
+   ///
+   /// @brief algorithm to calculate the deterministic sigma points for
+   /// the unscented transformation
+   ///
+   /// @param vecX mean of the normally distributed state
+   /// @param matPxx covariance of the normally distributed state
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   Matrix<DIM_A, SIGMA_DIM>
+   calculateSigmaPoints(const Vector<DIM_A> &vecXa, const Matrix<DIM_A, DIM_A> &matPa, const float32_t kappa)
+   {
+      const float32_t scalarMultiplier{std::sqrt(DIM_A + kappa)}; // sqrt(n + \kappa)
+
+      // cholesky factorization to get matrix Pxx square-root
+      Eigen::LLT<Matrix<DIM_A, DIM_A>> lltOfPa(matPa);
+      Matrix<DIM_A, DIM_A> matSa{lltOfPa.matrixL()}; // sqrt(P_{a})
+
+      matSa *= scalarMultiplier; // sqrt( (n + \kappa) * P_{a} )
+
+      Matrix<DIM_A, SIGMA_DIM> sigmaXa;
+
+      // X_0 = \bar{xa}
+      util::copyToColumn<DIM_A, SIGMA_DIM>(0, sigmaXa, vecXa);
+
+      for (int32_t i{0}; i < DIM_A; ++i) {
+         const int32_t IDX_1{i + 1};
+         const int32_t IDX_2{i + DIM_A + 1};
+
+         util::copyToColumn<DIM_A, SIGMA_DIM>(IDX_1, sigmaXa, vecXa);
+         util::copyToColumn<DIM_A, SIGMA_DIM>(IDX_2, sigmaXa, vecXa);
+
+         const Vector<DIM_A> vecShiftTerm{util::getColumnAt<DIM_A, DIM_A>(i, matSa)};
+
+         util::addColumnFrom<DIM_A, SIGMA_DIM>(IDX_1, sigmaXa, vecShiftTerm); // X_i^a     = \bar{xa} + sqrt( (n^a +
+                                                                              // \kappa) * P^{a} )
+         util::subColumnFrom<DIM_A, SIGMA_DIM>(IDX_2, sigmaXa, vecShiftTerm); // X_{i+n}^a = \bar{xa} - sqrt( (n^a +
+                                                                              // \kappa) * P^{a} )
+      }
+
+      return sigmaXa;
+   }
+
+   ///
+   /// @brief calculate the weighted mean and covariance given a set of sigma
+   /// points
+   /// @param sigmaX matrix of sigma points where each column contain single
+   /// sigma point
+   /// @param vecX output weighted mean
+   /// @param matP output weighted covariance
+   ///
+   template <int32_t STATE_DIM>
+   void calculateWeightedMeanAndCovariance(const Matrix<STATE_DIM, SIGMA_DIM> &sigmaX, Vector<STATE_DIM> &vecX,
+                                           Matrix<STATE_DIM, STATE_DIM> &matPxx)
+   {
+      // 1. calculate mean: \bar{y} = \sum_{i_0}^{2n} W[0, i] Y[:, i]
+      vecX = m_weight0 * util::getColumnAt<STATE_DIM, SIGMA_DIM>(0, sigmaX);
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         vecX += m_weighti * util::getColumnAt<STATE_DIM, SIGMA_DIM>(i, sigmaX); // y += W[0, i] Y[:, i]
+      }
+
+      // 2. calculate covariance: P_{yy} = \sum_{i_0}^{2n} W[0, i] (Y[:, i] -
+      // \bar{y}) (Y[:, i] - \bar{y})^T
+      Vector<STATE_DIM> devXi{util::getColumnAt<STATE_DIM, SIGMA_DIM>(0, sigmaX) - vecX}; // Y[:, 0] - \bar{ y }
+      matPxx = m_weight0 * devXi * devXi.transpose(); // P_0 = W[0, 0] (Y[:, 0] - \bar{y}) (Y[:, 0] -
+                                                      // \bar{y})^T
+
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         devXi = util::getColumnAt<STATE_DIM, SIGMA_DIM>(i, sigmaX) - vecX; // Y[:, i] - \bar{y}
+
+         const Matrix<STATE_DIM, STATE_DIM> Pi{m_weighti * devXi * devXi.transpose()}; // P_i = W[0, i] (Y[:, i] -
+                                                                                       // \bar{y}) (Y[:, i] - \bar{y})^T
+
+         matPxx += Pi; // y += W[0, i] (Y[:, i] - \bar{y}) (Y[:, i] - \bar{y})^T
+      }
+   }
+
+   ///
+   /// @brief calculate the cross-correlation given two sets sigma points X and Y
+   /// and their means x and y
+   /// @param sigmaX first matrix of sigma points where each column contain
+   /// single sigma point
+   /// @param vecX mean of the first set of sigma points
+   /// @param sigmaY second matrix of sigma points where each column contain
+   /// single sigma point
+   /// @param vecY mean of the second set of sigma points
+   /// @return matPxy, the cross-correlation matrix
+   ///
+   Matrix<DIM_X, DIM_Z> calculateCrossCorrelation(const Matrix<DIM_X, SIGMA_DIM> &sigmaX, const Vector<DIM_X> &vecX,
+                                                  const Matrix<DIM_Z, SIGMA_DIM> &sigmaY, const Vector<DIM_Z> &vecY)
+   {
+      Vector<DIM_X> devXi{util::getColumnAt<DIM_X, SIGMA_DIM>(0, sigmaX) - vecX}; // X[:, 0] - \bar{ x }
+      Vector<DIM_Z> devYi{util::getColumnAt<DIM_Z, SIGMA_DIM>(0, sigmaY) - vecY}; // Y[:, 0] - \bar{ y }
+
+      // P_0 = W[0, 0] (X[:, 0] - \bar{x}) (Y[:, 0] - \bar{y})^T
+      Matrix<DIM_X, DIM_Z> matPxy{m_weight0 * (devXi * devYi.transpose())};
+
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         devXi = util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaX) - vecX; // X[:, i] - \bar{x}
+         devYi = util::getColumnAt<DIM_Z, SIGMA_DIM>(i, sigmaY) - vecY; // Y[:, i] - \bar{y}
+
+         matPxy += m_weighti * (devXi * devYi.transpose()); // y += W[0, i] (Y[:, i] -
+                                                            // \bar{y}) (Y[:, i] - \bar{y})^T
+      }
+
+      return matPxy;
+   }
+};
+} // namespace kf
+
+#endif // UNSCENTED_KALMAN_FILTER_LIB_H

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_kalman_filter_test.cxx
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_kalman_filter_test.cxx
@@ -1,0 +1,137 @@
+#include "gtest/gtest.h"
+#include "kalman_filter/unscented_kalman_filter.h"
+
+class UnscentedKalmanFilterTest : public testing::Test {
+public:
+   virtual void SetUp() override {}
+   virtual void TearDown() override {}
+
+   static constexpr float FLOAT_EPSILON{0.001F};
+
+   static constexpr size_t DIM_X{4};
+   static constexpr size_t DIM_V{4};
+   static constexpr size_t DIM_Z{2};
+   static constexpr size_t DIM_N{2};
+
+   kf::UnscentedKalmanFilter<DIM_X, DIM_Z, DIM_V, DIM_N> m_ukf;
+
+   static kf::Vector<DIM_X> funcF(const kf::Vector<DIM_X> &x, const kf::Vector<DIM_V> &v)
+   {
+      kf::Vector<DIM_X> y;
+      y[0] = x[0] + x[2] + v[0];
+      y[1] = x[1] + x[3] + v[1];
+      y[2] = x[2] + v[2];
+      y[3] = x[3] + v[3];
+      return y;
+   }
+
+   static kf::Vector<DIM_Z> funcH(const kf::Vector<DIM_X> &x, const kf::Vector<DIM_N> &n)
+   {
+      kf::Vector<DIM_Z> y;
+
+      kf::float32_t px{x[0] + n[0]};
+      kf::float32_t py{x[1] + n[1]};
+
+      y[0] = std::sqrt((px * px) + (py * py));
+      y[1] = std::atan(py / (px + std::numeric_limits<kf::float32_t>::epsilon()));
+      return y;
+   }
+};
+
+TEST_F(UnscentedKalmanFilterTest, test_UKF_Example01)
+{
+   kf::Vector<DIM_X> x;
+   x << 2.0F, 1.0F, 0.0F, 0.0F;
+
+   kf::Matrix<DIM_X, DIM_X> P;
+   P << 0.01F, 0.0F, 0.0F, 0.0F, 0.0F, 0.01F, 0.0F, 0.0F, 0.0F, 0.0F, 0.05F, 0.0F, 0.0F, 0.0F, 0.0F, 0.05F;
+
+   kf::Matrix<DIM_V, DIM_V> Q;
+   Q << 0.05F, 0.0F, 0.0F, 0.0F, 0.0F, 0.05F, 0.0F, 0.0F, 0.0F, 0.0F, 0.1F, 0.0F, 0.0F, 0.0F, 0.0F, 0.1F;
+
+   kf::Matrix<DIM_N, DIM_N> R;
+   R << 0.01F, 0.0F, 0.0F, 0.01F;
+
+   kf::Vector<DIM_Z> z;
+   z << 2.5F, 0.05F;
+
+   m_ukf.vecX() = x;
+   m_ukf.matP() = P;
+
+   m_ukf.setCovarianceQ(Q);
+   m_ukf.setCovarianceR(R);
+
+   m_ukf.predictUKF(funcF);
+
+   // Expectation from the python results:
+   // =====================================
+   // x =
+   //     [2.0 1.0 0.0 0.0]
+   // P =
+   //     [[0.11  0.00  0.05  0.00]
+   //      [0.00  0.11  0.00  0.05]
+   //      [0.05  0.00  0.15  0.00]
+   //      [0.00  0.05  0.00  0.15]]
+
+   ASSERT_NEAR(m_ukf.vecX()[0], 2.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[1], 1.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[2], 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[3], 0.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(0, 0), 0.11F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 1), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 2), 0.05F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 3), 0.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(1, 0), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 1), 0.11F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 2), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 3), 0.05F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(2, 0), 0.05F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 1), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 2), 0.15F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 3), 0.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(3, 0), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 1), 0.05F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 2), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 3), 0.15F, FLOAT_EPSILON);
+
+   m_ukf.correctUKF(funcH, z);
+
+   // Expectations from the python results:
+   // ======================================
+   // x =
+   //     [ 2.554  0.356  0.252 -0.293]
+   // P =
+   //     [[ 0.01  -0.001  0.005 -0.    ]
+   //      [-0.001  0.01 - 0.     0.005 ]
+   //      [ 0.005 - 0.     0.129 - 0.  ]
+   //      [-0.     0.005 - 0.     0.129]]
+
+   ASSERT_NEAR(m_ukf.vecX()[0], 2.554F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[1], 0.356F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[2], 0.252F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.vecX()[3], -0.293F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(0, 0), 0.01F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 1), -0.001F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 2), 0.005F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(0, 3), 0.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(1, 0), -0.001F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 1), 0.01F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 2), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(1, 3), 0.005F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(2, 0), 0.005F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 1), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 2), 0.129F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(2, 3), 0.0F, FLOAT_EPSILON);
+
+   ASSERT_NEAR(m_ukf.matP()(3, 0), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 1), 0.005F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 2), 0.0F, FLOAT_EPSILON);
+   ASSERT_NEAR(m_ukf.matP()(3, 3), 0.129F, FLOAT_EPSILON);
+}

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_transform.h
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_transform.h
@@ -1,0 +1,220 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file unscented_transform.h
+///
+
+#ifndef UNSCENTED_TRANSFORM_H
+#define UNSCENTED_TRANSFORM_H
+
+#include "kf_util.h"
+#include "types.h"
+
+#include <iostream>
+
+#include "Eigen/Dense"
+#include "Eigen/src/Cholesky/LLT.h"
+
+namespace kf {
+template <int32_t DIM>
+class UnscentedTransform {
+public:
+   static constexpr int32_t SIGMA_DIM{(2 * DIM) + 1};
+
+   UnscentedTransform() {}
+   ~UnscentedTransform() {}
+
+   float32_t weight0() const { return _weights[0]; }
+   float32_t weighti() const { return _weights[1]; }
+
+   ///
+   /// @brief algorithm to execute weight and sigma points calculation
+   /// @param vecX input mean vector
+   /// @param matPxx input covariance matrix
+   /// @param kappa design parameter
+   ///
+   void compute(const Vector<DIM> &vecX, const Matrix<DIM, DIM> &matPxx, const float32_t kappa = 0.0F)
+   {
+      // 1. calculate weights
+      updateWeights(kappa);
+
+      // 2. update sigma points _sigmaX
+      updateSigmaPoints(vecX, matPxx, kappa);
+   }
+
+   template <int32_t DIM_X>
+   void calculateWeightedMeanAndCovariance(const Matrix<DIM_X, SIGMA_DIM> &sigmaX, Vector<DIM_X> &vecX,
+                                           Matrix<DIM_X, DIM_X> &matPxx)
+   {
+      // 1. calculate mean: \bar{y} = \sum_{i_0}^{2n} W[0, i] Y[:, i]
+      vecX = _weights[0] * util::getColumnAt<DIM_X, SIGMA_DIM>(0, sigmaX);
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         vecX += _weights[1] * util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaX); // y += W[0, i] Y[:, i]
+      }
+
+      // 2. calculate covariance: P_{yy} = \sum_{i_0}^{2n} W[0, i] (Y[:, i] -
+      // \bar{y}) (Y[:, i] - \bar{y})^T
+      Vector<DIM_X> devXi{util::getColumnAt<DIM_X, SIGMA_DIM>(0, sigmaX) - vecX}; // Y[:, 0] - \bar{ y }
+      matPxx = _weights[0] * devXi * devXi.transpose(); // P_0 = W[0, 0] (Y[:, 0] - \bar{y}) (Y[:, 0] -
+                                                        // \bar{y})^T
+
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         devXi = util::getColumnAt<DIM_X, SIGMA_DIM>(i, sigmaX) - vecX; // Y[:, i] - \bar{y}
+
+         const Matrix<DIM_X, DIM_X> Pi{_weights[1] * devXi * devXi.transpose()}; // P_i = W[0, i] (Y[:, i] - \bar{y})
+                                                                                 // (Y[:, i] - \bar{y})^T
+
+         matPxx += Pi; // y += W[0, i] (Y[:, i] - \bar{y}) (Y[:, i] - \bar{y})^T
+      }
+   }
+
+   ///
+   /// @brief algorithm to execute transforming sigma points through nonlinear
+   /// function and calculate the updated weights and covariance.
+   /// @param nonlinearFunction nonlinear function callback
+   /// @param vecY output mean vector (weighted mean vector)
+   /// @param matPyy output covariance matrix (weighted covariance matrix)
+   ///
+   template <typename NonLinearFunctionCallback>
+   void transform(NonLinearFunctionCallback nonlinearFunction, Vector<DIM> &vecY, Matrix<DIM, DIM> &matPyy)
+   {
+      Matrix<DIM, SIGMA_DIM> sigmaY;
+
+      // 3. transform sigma points X through the nonlinear model f(X) to obtain Y
+      // sigma points
+      transformSigmaPoints(nonlinearFunction, sigmaY);
+
+      // 4. calculate weight mean and covariance from the transformed sigma points
+      // Y and weights
+      updateTransformedMeanAndCovariance(sigmaY, vecY, matPyy);
+   }
+
+   void showSummary()
+   {
+      std::cout << "DIM_N : " << DIM << "\n";
+      std::cout << "DIM_M : " << SIGMA_DIM << "\n";
+      std::cout << "_weights[0] : \n" << _weights[0] << "\n";
+      std::cout << "_weights[1] : \n" << _weights[1] << "\n";
+      std::cout << "_sigmaX : \n" << _sigmaX << "\n";
+   }
+
+   Matrix<1, 2> &weights() { return _weights; }
+   const Matrix<1, 2> &weights() const { return _weights; }
+
+   Matrix<DIM, SIGMA_DIM> &sigmaX() { return _sigmaX; }
+   const Matrix<DIM, SIGMA_DIM> &sigmaX() const { return _sigmaX; }
+
+private:
+   /// @brief unscented transform weight 0 for mean
+   Matrix<1, 2> _weights;
+
+   /// @brief input sigma points
+   Matrix<DIM, SIGMA_DIM> _sigmaX;
+
+   ///
+   /// @brief algorithm to calculate the weights used to draw the sigma points
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   void updateWeights(float32_t kappa)
+   {
+      static_assert(DIM > 0, "DIM is Zero which leads to numerical issue.");
+
+      const float32_t denoTerm{kappa + static_cast<float32_t>(DIM)};
+
+      _weights[0] = kappa / denoTerm;
+      _weights[1] = 0.5F / denoTerm;
+   }
+
+   ///
+   /// @brief algorithm to calculate the deterministic sigma points for
+   /// the unscented transformation
+   ///
+   /// @param vecX mean of the normally distributed state
+   /// @param matPxx covariance of the normally distributed state
+   /// @param kappa design scaling parameter for sigma points selection
+   ///
+   void updateSigmaPoints(const Vector<DIM> &vecX, const Matrix<DIM, DIM> &matPxx, const float32_t kappa)
+   {
+      const float32_t scalarMultiplier{std::sqrt(DIM + kappa)}; // sqrt(n + \kappa)
+
+      // cholesky factorization to get matrix Pxx square-root
+      Eigen::LLT<Matrix<DIM, DIM>> lltOfPxx(matPxx);
+      Matrix<DIM, DIM> matSxx{lltOfPxx.matrixL()}; // sqrt(P_{xx})
+
+      matSxx *= scalarMultiplier; // sqrt( (n + \kappa) * P_{xx} )
+
+      // X_0 = \bar{x}
+      util::copyToColumn<DIM, SIGMA_DIM>(0, _sigmaX, vecX);
+
+      for (int32_t i{0}; i < DIM; ++i) {
+         const int32_t IDX_1{i + 1};
+         const int32_t IDX_2{i + DIM + 1};
+
+         util::copyToColumn<DIM, SIGMA_DIM>(IDX_1, _sigmaX, vecX);
+         util::copyToColumn<DIM, SIGMA_DIM>(IDX_2, _sigmaX, vecX);
+
+         const Vector<DIM> vecShiftTerm{util::getColumnAt<DIM, DIM>(i, matSxx)};
+
+         util::addColumnFrom<DIM, SIGMA_DIM>(IDX_1, _sigmaX,
+                                             vecShiftTerm); // X_i     = \bar{x} + sqrt( (n + \kappa) * P_{xx} )
+         util::subColumnFrom<DIM, SIGMA_DIM>(IDX_2, _sigmaX,
+                                             vecShiftTerm); // X_{i+n} = \bar{x} - sqrt( (n + \kappa) * P_{xx} )
+      }
+   }
+
+   ///
+   /// @brief transform sigma points X through the nonlinear function
+   /// @param nonlinearFunction nonlinear function to be used
+   /// @param sigmaY output transformed sigma points from the nonlinear function
+   ///
+   template <typename NonLinearFunctionCallback>
+   void transformSigmaPoints(NonLinearFunctionCallback nonlinearFunction, Matrix<DIM, SIGMA_DIM> &sigmaY)
+   {
+      for (int32_t i{0}; i < SIGMA_DIM; ++i) {
+         const Vector<DIM> x{util::getColumnAt<DIM, SIGMA_DIM>(i, _sigmaX)};
+         const Vector<DIM> y{nonlinearFunction(x)}; // y = f(x)
+
+         util::copyToColumn<DIM, SIGMA_DIM>(i, sigmaY, y); // Y[:, i] = y
+      }
+   }
+
+   ///
+   /// @brief calculate weighted mean and covariance given a set of sigma points
+   /// with associated weights.
+   /// @param sigmaY input transformed sigma points from the nonlinear function
+   /// @param vecY output weighted mean vector
+   /// @param matPyy output weighted covariance matrix
+   ///
+   void
+   updateTransformedMeanAndCovariance(const Matrix<DIM, SIGMA_DIM> &sigmaY, Vector<DIM> &vecY, Matrix<DIM, DIM> &matPyy)
+   {
+      // 1. calculate mean: \bar{y} = \sum_{i_0}^{2n} W[0, i] Y[:, i]
+      vecY = _weights[0] * util::getColumnAt<DIM, SIGMA_DIM>(0, sigmaY);
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         vecY += _weights[1] * util::getColumnAt<DIM, SIGMA_DIM>(i, sigmaY); // y += W[0, i] Y[:, i]
+      }
+
+      // 2. calculate covariance: P_{yy} = \sum_{i_0}^{2n} W[0, i] (Y[:, i] -
+      // \bar{y}) (Y[:, i] - \bar{y})^T
+      Vector<DIM> devYi{util::getColumnAt<DIM, SIGMA_DIM>(0, sigmaY) - vecY}; // Y[:, 0] - \bar{ y }
+      matPyy = _weights[0] * devYi * devYi.transpose(); // P_0 = W[0, 0] (Y[:, 0] - \bar{y}) (Y[:, 0] -
+                                                        // \bar{y})^T
+
+      for (int32_t i{1}; i < SIGMA_DIM; ++i) {
+         devYi = util::getColumnAt<DIM, SIGMA_DIM>(i, sigmaY) - vecY; // Y[:, i] - \bar{y}
+
+         const Matrix<DIM, DIM> Pi{_weights[1] * devYi * devYi.transpose()}; // P_i = W[0, i] (Y[:, i] - \bar{y}) (Y[:,
+                                                                             // i] - \bar{y})^T
+
+         matPyy += Pi; // y += W[0, i] (Y[:, i] - \bar{y}) (Y[:, i] - \bar{y})^T
+      }
+   }
+};
+} // namespace kf
+
+#endif // UNSCENTED_TRANSFORM_H

--- a/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_trasform_test.cpp
+++ b/AtReconstruction/AtFitter/OpenKF/kalman_filter/unscented_trasform_test.cpp
@@ -1,0 +1,73 @@
+#include "kalman_filter/unscented_transform.h"
+#include "gtest/gtest.h"
+
+class UnscentedTransformTest : public testing::Test
+{
+ public:
+  virtual void SetUp() override {}
+  virtual void TearDown() override {}
+
+  static constexpr float ASSERT_FLT_EPSILON{0.00001F};
+
+  static constexpr size_t DIM_1{1};
+  static constexpr size_t DIM_2{2};
+
+  static kf::Vector<DIM_1> function1(const kf::Vector<DIM_1>& x)
+  {
+    kf::Vector<DIM_1> y;
+    y[0] = x[0] * x[0];
+    return y;
+  }
+
+  static kf::Vector<DIM_2> function2(const kf::Vector<DIM_2>& x)
+  {
+    kf::Vector<DIM_2> y;
+    y[0] = x[0] * x[0];
+    y[1] = x[1] * x[1];
+    return y;
+  }
+};
+
+TEST_F(UnscentedTransformTest, test_unscentedTransform_Example1)
+{
+  kf::Vector<DIM_1> x;
+  x << 0.0F;
+
+  kf::Matrix<DIM_1, DIM_1> P;
+  P << 0.5F;
+
+  kf::UnscentedTransform<DIM_1> UT;
+  UT.compute(x, P, 0.0F);
+
+  kf::Vector<DIM_1> vecY;
+  kf::Matrix<DIM_1, DIM_1> matPyy;
+
+  UT.transform(function1, vecY, matPyy);
+
+  ASSERT_NEAR(vecY[0], 0.5F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(matPyy[0], 0.0F, ASSERT_FLT_EPSILON);
+}
+
+TEST_F(UnscentedTransformTest, test_unscentedTransform_Example2)
+{
+  kf::Vector<DIM_2> x;
+  x << 2.0F, 1.0F;
+
+  kf::Matrix<DIM_2, DIM_2> P;
+  P << 0.1F, 0.0F, 0.0F, 0.1F;
+
+  kf::UnscentedTransform<DIM_2> UT;
+  UT.compute(x, P, 0.0F);
+
+  kf::Vector<DIM_2> vecY;
+  kf::Matrix<DIM_2, DIM_2> matPyy;
+
+  UT.transform(function2, vecY, matPyy);
+
+  ASSERT_NEAR(vecY[0], 4.1F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(vecY[1], 1.1F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(matPyy(0, 0), 1.61F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(matPyy(0, 1), -0.01F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(matPyy(1, 0), -0.01F, ASSERT_FLT_EPSILON);
+  ASSERT_NEAR(matPyy(1, 1), 0.41F, ASSERT_FLT_EPSILON);
+}

--- a/AtReconstruction/AtFitter/OpenKF/kf_util.h
+++ b/AtReconstruction/AtFitter/OpenKF/kf_util.h
@@ -1,0 +1,208 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file util.h
+///
+
+#ifndef KALMAN_FILTER_UTIL_H
+#define KALMAN_FILTER_UTIL_H
+
+#include <Eigen/Dense>
+
+#include "types.h"
+
+namespace kf {
+namespace util {
+template <int32_t ROWS, int32_t COLS>
+void copyToColumn(const int32_t colIdx, Matrix<ROWS, COLS> &lhsSigmaX, const Vector<ROWS> &rhsVecX)
+{
+   for (int32_t i{0}; i < ROWS; ++i) { // rows
+      lhsSigmaX(i, colIdx) = rhsVecX[i];
+   }
+}
+
+template <int32_t ROWS, int32_t COLS>
+void addColumnFrom(const int32_t colIdx, Matrix<ROWS, COLS> &lhsSigmaX, const Vector<ROWS> &rhsVecX)
+{
+   for (int32_t i{0}; i < ROWS; ++i) { // rows
+      lhsSigmaX(i, colIdx) += rhsVecX[i];
+   }
+}
+
+template <int32_t ROWS, int32_t COLS>
+void subColumnFrom(const int32_t colIdx, Matrix<ROWS, COLS> &lhsSigmaX, const Vector<ROWS> &rhsVecX)
+{
+   for (int32_t i{0}; i < ROWS; ++i) { // rows
+      lhsSigmaX(i, colIdx) -= rhsVecX[i];
+   }
+}
+
+template <int32_t ROWS, int32_t COLS>
+Vector<ROWS> getColumnAt(const int32_t colIdx, const Matrix<ROWS, COLS> &matX)
+{
+   assert(colIdx < COLS); // assert if colIdx is out of boundary
+
+   Vector<ROWS> vecXi;
+
+   for (int32_t i{0}; i < ROWS; ++i) { // rows
+      vecXi[i] = matX(i, colIdx);
+   }
+
+   return vecXi;
+}
+
+template <int32_t ROWS, int32_t COLS, int32_t N_ROWS, int32_t N_COLS>
+Matrix<N_ROWS, N_COLS> getBlock(const Matrix<ROWS, COLS> &matA, int32_t startRowIdx, int32_t startColIdx)
+{
+   Matrix<N_ROWS, N_COLS> matB;
+
+   for (int32_t i = startRowIdx; i < startRowIdx + N_ROWS; ++i) {
+      for (int32_t j = startColIdx; j < startColIdx + N_COLS; ++j) {
+         matB(i - startRowIdx, j - startColIdx) = matA(i, j);
+      }
+   }
+
+   return matB;
+}
+
+template <int32_t ROWS, int32_t COLS>
+Matrix<ROWS, COLS> getUpperTriangulerView(const Matrix<ROWS, COLS> &matA)
+{
+   Matrix<ROWS, COLS> matB;
+   for (int32_t i = 0; i < ROWS; ++i) {
+      for (int32_t j = i; j < COLS; ++j) {
+         matB(i, j) = matA(i, j);
+         if (i != j) {
+            matB(j, i) = 0.0F;
+         }
+      }
+   }
+   return matB;
+}
+
+template <int32_t ROWS, int32_t COLS_L, int32_t COLS_W>
+Matrix<ROWS, COLS_L> cholupdate(Matrix<ROWS, COLS_L> matL, Matrix<ROWS, COLS_W> matW, float32_t alpha)
+{
+   Matrix<ROWS, COLS_L> matLo;
+
+   for (int32_t i{0}; i < COLS_W; ++i) {
+      matLo = matL;
+
+      float32_t b{1.0F};
+
+      for (int32_t j{0}; j < ROWS; ++j) {
+         const float32_t ljjPow2{matL(j, j) * matL(j, j)};
+         const float32_t wjiPow2{matW(j, i) * matW(j, i)};
+         const float32_t upsilon{(ljjPow2 * b) + (alpha * wjiPow2)};
+
+         matLo(j, j) = std::sqrt(ljjPow2 + ((alpha / b) * wjiPow2));
+
+         for (int32_t k{j + 1}; k < ROWS; ++k) {
+            matW(k, i) -= (matW(j, i) / matL(j, j)) * matL(k, j);
+            matLo(k, j) =
+               ((matLo(j, j) / matL(j, j)) * matL(k, j)) + (matLo(j, j) * alpha * matW(j, i) * matW(k, i) / upsilon);
+         }
+
+         b += alpha * (wjiPow2 / ljjPow2);
+      }
+
+      matL = matLo;
+   }
+   return matLo;
+}
+
+template <int32_t ROWS, int32_t COLS>
+Matrix<ROWS, COLS> forwardSubstitute(const Matrix<ROWS, ROWS> &matA, const Matrix<ROWS, COLS> &matB)
+{
+   Matrix<ROWS, COLS> matX;
+
+   for (int32_t k{0}; k < COLS; ++k) {
+      for (int32_t i{0}; i < ROWS; ++i) {
+         float32_t accumulation{matB(i, k)};
+         for (int32_t j{0}; j < i; ++j) {
+            accumulation -= matA(i, j) * matX(j, k);
+         }
+
+         matX(i, k) = accumulation / matA(i, i);
+      }
+   }
+   return matX;
+}
+
+template <int32_t ROWS, int32_t COLS>
+Matrix<ROWS, COLS> backwardSubstitute(const Matrix<ROWS, ROWS> &matA, const Matrix<ROWS, COLS> &matB)
+{
+   Matrix<ROWS, COLS> matX;
+
+   for (int32_t k{0}; k < COLS; ++k) {
+      for (int32_t i{ROWS - 1}; i >= 0; --i) {
+         float32_t accumulation{matB(i, k)};
+
+         for (int32_t j{ROWS - 1}; j > i; --j) {
+            accumulation -= matA(i, j) * matX(j, k);
+         }
+
+         matX(i, k) = accumulation / matA(i, i);
+      }
+   }
+   return matX;
+}
+
+template <int32_t ROWS1, int32_t ROWS2, int32_t COLS>
+class JointRows {
+public:
+   JointRows() = delete;
+   ~JointRows() {}
+
+   explicit JointRows(const Matrix<ROWS1, COLS> &matM1, const Matrix<ROWS2, COLS> &matM2)
+   {
+      for (int32_t j{0}; j < COLS; ++j) {
+         for (int32_t i{0}; i < ROWS1; ++i) {
+            m_matJ(i, j) = matM1(i, j);
+         }
+
+         for (int32_t i{0}; i < ROWS2; ++i) {
+            m_matJ(i + ROWS1, j) = matM2(i, j);
+         }
+      }
+   }
+
+   const Matrix<ROWS1 + ROWS2, COLS> &jointMatrix() const { return m_matJ; }
+
+private:
+   Matrix<ROWS1 + ROWS2, COLS> m_matJ;
+};
+
+template <int32_t ROWS, int32_t COLS1, int32_t COLS2>
+class JointCols {
+public:
+   JointCols() = delete;
+   ~JointCols() {}
+
+   explicit JointCols(const Matrix<ROWS, COLS1> &matM1, const Matrix<ROWS, COLS2> &matM2)
+   {
+      for (int32_t i{0}; i < ROWS; ++i) {
+         for (int32_t j{0}; j < COLS1; ++j) {
+            m_matJ(i, j) = matM1(i, j);
+         }
+
+         for (int32_t j{0}; j < COLS2; ++j) {
+            m_matJ(i, j + COLS1) = matM2(i, j);
+         }
+      }
+   }
+
+   const Matrix<ROWS, COLS1 + COLS2> &jointMatrix() const { return m_matJ; }
+
+private:
+   Matrix<ROWS, COLS1 + COLS2> m_matJ;
+};
+} // namespace util
+} // namespace kf
+
+#endif // KALMAN_FILTER_UTIL_H

--- a/AtReconstruction/AtFitter/OpenKF/types.h
+++ b/AtReconstruction/AtFitter/OpenKF/types.h
@@ -1,0 +1,29 @@
+///
+/// Copyright 2022 Mohanad Youssef (Al-khwarizmi)
+///
+/// Use of this source code is governed by an GPL-3.0 - style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/GPL-3.0
+///
+/// @author Mohanad Youssef <mohanad.magdy.hammad@gmail.com>
+/// @file types.h
+///
+
+#ifndef OPENKF_TYPES_H
+#define OPENKF_TYPES_H
+
+#include <Eigen/Dense>
+
+#include <stdint.h>
+
+namespace kf {
+using float32_t = float;
+
+template <int32_t ROW, int32_t COL>
+using Matrix = Eigen::Matrix<float32_t, ROW, COL>;
+
+template <int32_t ROW>
+using Vector = Eigen::Matrix<float32_t, ROW, 1>;
+} // namespace kf
+
+#endif // OPENKF_TYPES_H

--- a/AtReconstruction/AtPatternRecognition/trackfinder/fastcluster_dm.cxx
+++ b/AtReconstruction/AtPatternRecognition/trackfinder/fastcluster_dm.cxx
@@ -342,7 +342,7 @@ public:
 // We require r_ < c_ !
 #define D_(r_, c_) (D[(static_cast<std::ptrdiff_t>(2 * N - 3 - (r_)) * (r_) >> 1) + (c_)-1])
 // Z is an ((N-1)x4)-array
-#define Z_(_r, _c) (Z[(_r)*4 + (_c)])
+#define Z_(_r, _c) (Z[(_r) * 4 + (_c)])
 
 /*
   Lookup function for a union-find data structure.

--- a/AtReconstruction/AtPatternRecognition/triplclust/src/hclust/fastcluster_dm.cxx
+++ b/AtReconstruction/AtPatternRecognition/triplclust/src/hclust/fastcluster_dm.cxx
@@ -342,7 +342,7 @@ public:
 // We require r_ < c_ !
 #define D_(r_, c_) (D[(static_cast<std::ptrdiff_t>(2 * N - 3 - (r_)) * (r_) >> 1) + (c_)-1])
 // Z is an ((N-1)x4)-array
-#define Z_(_r, _c) (Z[(_r)*4 + (_c)])
+#define Z_(_r, _c) (Z[(_r) * 4 + (_c)])
 
 /*
   Lookup function for a union-find data structure.

--- a/AtReconstruction/AtReconstructionLinkDef.h
+++ b/AtReconstruction/AtReconstructionLinkDef.h
@@ -39,6 +39,9 @@
 
 #pragma link C++ class AtMacroTask + ;
 
+#pragma link C++ namespace kf;
+#pragma link C++ namespace kf::util;
+
 /* Classes that depend on Genfit2 */
 #pragma link C++ class genfit::AtSpacepointMeasurement + ;
 #pragma link C++ class AtFITTER::AtFitter + ;

--- a/AtReconstruction/CMakeLists.txt
+++ b/AtReconstruction/CMakeLists.txt
@@ -11,6 +11,9 @@ ${CMAKE_SOURCE_DIR}/AtReconstruction/AtPatternRecognition
 #${CMAKE_SOURCE_DIR}/AtReconstruction/AtPatternRecognition/trackfinder
 ${CMAKE_SOURCE_DIR}/AtReconstruction/AtFitter
 ${CMAKE_SOURCE_DIR}/AtReconstruction/AtFitter/ParameterDistributions
+${CMAKE_SOURCE_DIR}/AtReconstruction/AtFitter/OpenKF
+${CMAKE_SOURCE_DIR}/AtReconstruction/AtFitter/OpenKF/kalman_filter
+
 ${CMAKE_SOURCE_DIR}/AtReconstruction/AtFilter
 ${CMAKE_SOURCE_DIR}/AtReconstruction/AtPatternRecognition/triplclust/src
 ${CMAKE_SOURCE_DIR}/AtReconstruction/AtPatternRecognition/triplclust/src/hclust
@@ -85,7 +88,6 @@ set(SRCS
   
   AtPatternRecognition/triplclust/src/cluster.cxx
   AtPatternRecognition/triplclust/src/triplet.cxx
-  AtPatternRecognition/triplclust/src/main.cxx
   AtPatternRecognition/triplclust/src/dnn.cxx
   AtPatternRecognition/triplclust/src/hclust/fastcluster.cxx
   AtPatternRecognition/triplclust/src/kdtree/kdtree.cxx
@@ -109,12 +111,39 @@ set(SRCS
   AtFitter/AtMCFission.cxx
   )
 
-### Add additional sources and libraries if we found certain modules ###
 
-if(TARGET EIGEN3::Eigen)
-  set(SRC ${SRC}
+### Add additional sources and libraries if we found certain modules ###
+if(TARGET Eigen3::Eigen)
+
+  message(STATUS "EIGEN3::Eigen target found. Enabling Eigen-dependent sources.")
+
+  set(SRCS ${SRCS}
   AtPatternRecognition/triplclust/src/orthogonallsq.cxx
+  AtFitter/AtOpenKFTest.cxx
   )
+  message(STATUS "Current sources: ${SRCS}")
+
+  set(HDRS_ADD
+    AtFitter/OpenKF/kalman_filter/kalman_filter.h
+    #AtFitter/OpenKF/kalman_filter/square_root_ukf.h
+    AtFitter/OpenKF/kalman_filter/unscented_kalman_filter.h
+    #AtFitter/OpenKF/kalman_filter/unscented_transform.h
+    AtFitter/OpenKF/types.h
+    AtFitter/OpenKF/kf_util.h
+    )
+  set(DEPENDENCIES ${DEPENDENCIES}
+    Eigen3::Eigen
+   )
+
+   set(TEST_SRCS_OPENKF
+    AtFitter/OpenKF/kalman_filter/kalman_filter_test.cxx
+    AtFitter/OpenKF/kalman_filter/unscented_kalman_filter_test.cxx
+    )
+ 
+ attpcroot_generate_tests(OpenKFTests
+   SRCS ${TEST_SRCS_OPENKF}
+   DEPS ${LIBRARY_NAME}
+   )
 endif()
 
 if(GENFIT2_FOUND)
@@ -129,15 +158,6 @@ if(GENFIT2_FOUND)
    )
 endif()
 
-if(TARGET OpenKF)
-  set(SRCS ${SRCS}
-    AtFitter/AtOpenKFTest.cxx
-    )
-  set(DEPENDENCIES ${DEPENDENCIES}
-    OpenKF
-    )
-endif()
-
 if(HiRAEVT_FOUND)
   set(SRCS ${SRCS}
     AtLinkDAQTask.cxx
@@ -147,9 +167,13 @@ if(HiRAEVT_FOUND)
     )
 endif()
 
+
+
+
 generate_target_and_root_library(${LIBRARY_NAME}
   LINKDEF ${LINKDEF}
   SRCS ${SRCS}
+  HDRS_ADD ${HDRS_ADD}
   INCLUDE_DIR ${INCLUDE_DIRECTORIES}
   LIBRARY_DIR ${LINK_DIRECTORIES}
   DEPS_PUBLIC ${DEPENDENCIES}

--- a/AtS800/S800.cxx
+++ b/AtS800/S800.cxx
@@ -135,19 +135,19 @@ unsigned short *S800::DecodeS800TimeOfFlight(unsigned short *p)
       int tmp = *p;
       ++p;
       if (ch == 12)
-         rf = (tmp)&0xfff;
+         rf = (tmp) & 0xfff;
       else if (ch == 13)
-         obj = (tmp)&0xfff;
+         obj = (tmp) & 0xfff;
       else if (ch == 14)
-         xfp = (tmp)&0xfff;
+         xfp = (tmp) & 0xfff;
       else if (ch == 15)
-         si = (tmp)&0xfff;
+         si = (tmp) & 0xfff;
       else if (ch == 5)
-         tac_obj = (tmp)&0xfff;
+         tac_obj = (tmp) & 0xfff;
       else if (ch == 4)
-         tac_xfp = (tmp)&0xfff;
+         tac_xfp = (tmp) & 0xfff;
       else if (ch > 0 && ch < 8)
-         dum = (tmp)&0xfff; // NOLINT
+         dum = (tmp) & 0xfff; // NOLINT
       words--;
    }
    this->GetTimeOfFlight()->Set(rf, obj, xfp, si);

--- a/cmake/modules/ROOTTargetMacros.cmake
+++ b/cmake/modules/ROOTTargetMacros.cmake
@@ -22,6 +22,7 @@
 # LINKDEF: Name of the linkdef file (will skip dictionary generation of not present)
 # HDRS: List of all header files to use in library generation.
 #     - Will use all SRCS renamed from .cxx to .h if empty
+# HDRS_ADD: List of additional header files to use in library generation.
 # INCLUDE_DIR: List of include directories in addition to:
 #     -CMAKE_CURRENT_SOURCE_DIR
 # LIBRARY_DIR: List of link directories in addition to ROOT_LIBRARY_DIR
@@ -34,7 +35,7 @@ function(generate_target_and_root_library target)
     HT
     ""
     ""
-    "SRCS;HDRS;INCLUDE_DIR;LIBRARY_DIR;DEPS_PUBLIC;DEPS_PRIVATE;LINKDEF"
+    "SRCS;HDRS;HDRS_ADD;INCLUDE_DIR;LIBRARY_DIR;DEPS_PUBLIC;DEPS_PRIVATE;LINKDEF"
     )
 
   # Check for required and set defaults
@@ -52,6 +53,11 @@ function(generate_target_and_root_library target)
       FILES "${HT_SRCS}"
       OUTVAR HT_HDRS)
   endif()
+
+  set(DICT_HDRS ${HT_HDRS})
+
+
+  list(APPEND HT_HDRS ${HT_HDRS_ADD})
 
   # Add defaults to include directories
   list(APPEND HT_INCLUDE_DIR 
@@ -112,7 +118,7 @@ function(generate_target_and_root_library target)
   # Make the dictionary
   foreach(h ${HT_LINKDEF})
     make_target_root_dictionary( ${target}
-      HEADERS ${HT_HDRS}
+      HEADERS ${DICT_HDRS}
       LINKDEF ${h})
   endforeach()
 


### PR DESCRIPTION
Allow additional headers to be added to libraries that are not used in the generation of the ROOT dictionary. As a result these are not in the ROOT map, so are not accessible from the ROOT interpreter, but can be included in other C++ code in the library. This works for OpenKF as I think we will have classes that wrap these header only classes which can be easily included in the ROOT map.

Needed to rename util.h to kf_util.h to avoid conflict with tripclust, which also includes a util.h header.

Removed the main function from tripclust. It interferes with the generation of any tests that link against the AtReconstruction library.

Add existing OpenKF tests to our test suite

Updated clang-format version to v17.

Version 16 (what we were using) is not available in some Ubuntu distributions, but v17 is widely available though package managers with LLVM's official APT repo.