### PR TITLE
Created a CATIMA wrapper as an AtELossModel. Included a test comparing with results from LISE.

### DIFF
--- a/AtTools/AtELossCATIMA.cxx
+++ b/AtTools/AtELossCATIMA.cxx
@@ -5,7 +5,7 @@
 AtTools::AtELossCATIMA::AtELossCATIMA(double density, std::vector<std::tuple<int, int, int>> materialComponents)
    : AtELossModel(density)
 {
-   fMaterial = new catima::Material();
+   fMaterial = std::make_unique<catima::Material>();
 
    for (auto materialComponent : materialComponents)
       fMaterial->add_element(std::get<0>(materialComponent), std::get<1>(materialComponent),

--- a/AtTools/AtELossCATIMA.cxx
+++ b/AtTools/AtELossCATIMA.cxx
@@ -1,0 +1,88 @@
+#include "AtELossCATIMA.h"
+
+#include <FairLogger.h>
+
+AtTools::AtELossCATIMA::AtELossCATIMA(double density, std::vector<std::tuple<int, int, int>> materialComponents)
+   : AtELossModel(density)
+{
+   fMaterial = new catima::Material();
+
+   for (auto materialComponent : materialComponents)
+      fMaterial->add_element(std::get<0>(materialComponent), std::get<1>(materialComponent),
+                             std::get<2>(materialComponent));
+}
+
+double AtTools::AtELossCATIMA::GetdEdx(double energy) const
+{
+   if (fProjectile == nullptr) {
+      LOG(warning)
+         << " Warning in AtTools::AtELossCATIMA::GetdEdx : The projectile was not set! GetdEdx will return 0!";
+      return 0;
+   }
+
+   if (fProjectileMassUma <= 0) {
+      LOG(error) << " Error in AtTools::AtELossCATIMA::GetdEdx : The projectile's mass in umas can not be <= 0! "
+                    "GetdEdx will return 0!";
+      return 0;
+   }
+
+   catima::Result result = catima::calculate(*fProjectile, *fMaterial, energy / fProjectileMassUma);
+   double dEdx = result.dEdxi * fDensity;
+   return dEdx;
+}
+
+double AtTools::AtELossCATIMA::GetRange(double energyIni, double energyFin) const
+{
+   if (energyFin < 0) {
+      LOG(warning) << " Warning in AtTools::AtELossCATIMA::GetRange : The final energy was set to a negative value! "
+                      "Setting energyFin to 0!";
+      energyFin = 0;
+   }
+
+   if (energyFin == 0) {
+      fProjectile->T = energyIni / fProjectileMassUma;
+      return catima::range(*fProjectile, *fMaterial) / fDensity * 10.;
+   }
+
+   double remainingEnergy{energyIni};
+   double range{0};
+   while (remainingEnergy > energyFin) {
+      catima::Result result = catima::calculate(*fProjectile, *fMaterial, remainingEnergy / fProjectileMassUma);
+      double dEdx = result.dEdxi * fDensity;
+      double DE = dEdx * fRangeStepSize / 10.;
+
+      if (remainingEnergy - energyFin > DE) {
+         range += fRangeStepSize;
+         remainingEnergy -= DE;
+      } else {
+         range += (remainingEnergy - energyFin) / dEdx * 10.;
+         remainingEnergy = energyFin;
+         break;
+      }
+   }
+   return range;
+}
+
+double AtTools::AtELossCATIMA::GetEnergy(double energyIni, double distance) const
+{
+   double remainingEnergy{energyIni};
+   double range{0};
+   while (range < distance) {
+      catima::Result result = catima::calculate(*fProjectile, *fMaterial, remainingEnergy / fProjectileMassUma);
+      double dEdx = result.dEdxi * fDensity;
+      double DE{};
+
+      if (range + fRangeStepSize < distance) {
+         DE = dEdx * fRangeStepSize / 10.;
+         range += fRangeStepSize;
+         remainingEnergy -= DE;
+      } else {
+         DE = dEdx * (distance - range) / 10.;
+         range = distance;
+         remainingEnergy -= DE;
+         break;
+      }
+   }
+
+   return remainingEnergy;
+}

--- a/AtTools/AtELossCATIMA.h
+++ b/AtTools/AtELossCATIMA.h
@@ -5,6 +5,7 @@
 #include "AtELossModel.h"
 
 #include <catima/catima.h>
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -12,8 +13,8 @@ namespace AtTools {
 
 class AtELossCATIMA : public AtELossModel {
 protected:
-   catima::Material *fMaterial{nullptr};
-   catima::Projectile *fProjectile{nullptr};
+   std::unique_ptr<catima::Material> fMaterial{nullptr};
+   std::unique_ptr<catima::Projectile> fProjectile{nullptr};
 
    double fProjectileMassUma{-1};
 
@@ -44,7 +45,7 @@ public:
     */
    void SetProjectile(double A, double Z, double massUma)
    {
-      fProjectile = new catima::Projectile(A, Z);
+      fProjectile = std::make_unique<catima::Projectile>(A, Z);
       fProjectileMassUma = massUma;
    }
    /**

--- a/AtTools/AtELossCATIMA.h
+++ b/AtTools/AtELossCATIMA.h
@@ -1,0 +1,59 @@
+#ifndef ATELOSSCATIMA_H
+#define ATELOSSCATIMA_H
+// IWYU pragma: no_include <ext/alloc_traits.h>
+
+#include "AtELossModel.h"
+
+#include <catima/catima.h>
+#include <tuple>
+#include <vector>
+
+namespace AtTools {
+
+class AtELossCATIMA : public AtELossModel {
+protected:
+   catima::Material *fMaterial{nullptr};
+   catima::Projectile *fProjectile{nullptr};
+
+   double fProjectileMassUma{-1};
+
+   double fRangeStepSize{0.1}; // mm
+
+public:
+   /**
+    * Initializer of the CATIMA AtELossModel wrapper.
+    * @param[in] density Density of the material.
+    * @param[in] materialComponents Components of the material. They are passed as a vector of tuples (A, Z,
+    * stoichiometry).
+    */
+   AtELossCATIMA(double density, std::vector<std::tuple<int, int, int>> materialComponents);
+
+   virtual double GetdEdx(double energy) const override;
+   virtual double GetRange(double energyIni, double energyFin = 0) const override;
+   virtual double GetEnergyLoss(double energyIni, double distance) const override
+   {
+      return energyIni - GetEnergy(energyIni, distance);
+   }
+   virtual double GetEnergy(double energyIni, double distance) const override;
+
+   /**
+    * Setter of the catima projectile used for calculations.
+    * @param[in] A Mass number of the projectile.
+    * @param[in] Z Charge number of the projectile.
+    * @param[in] massUma Mass of the projectile in umas.
+    */
+   void SetProjectile(double A, double Z, double massUma)
+   {
+      fProjectile = new catima::Projectile(A, Z);
+      fProjectileMassUma = massUma;
+   }
+   /**
+    * Setter of the range step size used for calculations. By default it is set to 0.1mm.
+    * @param[in] stepSize The step size used for ranges. It must be input in mm.
+    */
+   void SetRangeStepSize(double stepSize) { fRangeStepSize = stepSize; }
+};
+
+} // namespace AtTools
+
+#endif

--- a/AtTools/AtELossCATIMATest.cxx
+++ b/AtTools/AtELossCATIMATest.cxx
@@ -1,0 +1,85 @@
+#include "AtELossCATIMA.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+TEST(AtELossCATIMATest, LISE_Match)
+{
+   // Create the vector with the gas components for H2.
+   std::vector<std::tuple<int, int, int>> components;
+   components.push_back({1, 1, 1}); // (A, Z, stoichiometry)
+
+   // Calculate the gas density for 600Torr H2 from LISE.
+   double density = 6.5643e-5; // g/cm3
+
+   // Create the CATIMA ELoss model.
+   AtTools::AtELossCATIMA catimaModel(density, components);
+
+   // Set the projectile to proton.
+   catimaModel.SetProjectile(1, 1, 1.007825031898); // (A, Z, massUMA)
+
+   // Calculate ranges for different energies with LISE.
+   std::vector<std::pair<double, double>> kinEnergyRange; // (MeV, mm)
+   kinEnergyRange.push_back(std::make_pair(1, 1.33e2));
+   kinEnergyRange.push_back(std::make_pair(5, 2.2381e3));
+   kinEnergyRange.push_back(std::make_pair(10, 7.8883e3));
+
+   // Compare with the results from this class.
+   for (auto pair : kinEnergyRange) {
+      double energy = pair.first;
+      double rangeLISE = pair.second;
+
+      double range = catimaModel.GetRange(energy);
+      EXPECT_TRUE(std::abs(range - rangeLISE) / rangeLISE < 0.05);
+   }
+
+   // Calculate ELosses for different distances using LISE at 10MeV initial energy.
+   std::vector<std::pair<double, double>> distanceELoss; // (mm, MeV)
+   distanceELoss.push_back(std::make_pair(100, 0.0694));
+   distanceELoss.push_back(std::make_pair(1000, 0.7138));
+   distanceELoss.push_back(std::make_pair(5000, 4.2409));
+
+   // Compare with the results from this class.
+   for (auto pair : distanceELoss) {
+      double distance = pair.first;
+      double ELossLISE = pair.second;
+
+      double ELoss = catimaModel.GetEnergyLoss(10, distance);
+      EXPECT_TRUE(std::abs(ELoss - ELossLISE) / ELossLISE < 0.05);
+   }
+
+   // Do the same for 4He projectile.
+   catimaModel.SetProjectile(4, 2, 4.00260325413); // (A, Z, massUMA)
+
+   std::vector<std::pair<double, double>> kinEnergyRange4He; // (MeV, mm)
+   kinEnergyRange4He.push_back(std::make_pair(1, 2.5742e1));
+   kinEnergyRange4He.push_back(std::make_pair(5, 2.0547e2));
+   kinEnergyRange4He.push_back(std::make_pair(10, 6.5724e2));
+
+   // Compare with the results from this class.
+   for (auto pair : kinEnergyRange4He) {
+      double energy = pair.first;
+      double rangeLISE = pair.second;
+
+      double range = catimaModel.GetRange(energy);
+      EXPECT_TRUE(std::abs(range - rangeLISE) / rangeLISE < 0.05);
+   }
+
+   // Calculate ELosses for different distances using LISE at 10MeV initial energy.
+   std::vector<std::pair<double, double>> distanceELoss4He; // (mm, MeV)
+   distanceELoss4He.push_back(std::make_pair(100, 0.9121));
+   distanceELoss4He.push_back(std::make_pair(500, 5.7726));
+   distanceELoss4He.push_back(std::make_pair(1000, 10));
+
+   // Compare with the results from this class.
+   for (auto pair : distanceELoss4He) {
+      double distance = pair.first;
+      double ELossLISE = pair.second;
+
+      double ELoss = catimaModel.GetEnergyLoss(10, distance);
+      EXPECT_TRUE(std::abs(ELoss - ELossLISE) / ELossLISE < 0.05);
+   }
+}

--- a/AtTools/AtELossCATIMATest.cxx
+++ b/AtTools/AtELossCATIMATest.cxx
@@ -10,7 +10,7 @@ TEST(AtELossCATIMATest, LISE_Match)
 {
    // Create the vector with the gas components for H2.
    std::vector<std::tuple<int, int, int>> components;
-   components.push_back({1, 1, 1}); // (A, Z, stoichiometry)
+   components.push_back({1, 1, 2}); // (A, Z, stoichiometry)
 
    // Calculate the gas density for 600Torr H2 from LISE.
    double density = 6.5643e-5; // g/cm3
@@ -82,4 +82,11 @@ TEST(AtELossCATIMATest, LISE_Match)
       double ELoss = catimaModel.GetEnergyLoss(10, distance);
       EXPECT_TRUE(std::abs(ELoss - ELossLISE) / ELossLISE < 0.05);
    }
+
+   // Finally, for 4He, we test if GetRange works when setting a non-zero final energy.
+   double energyIni{10};
+   double energyFin{4.227};
+   double rangeLISE{500};
+   double range = catimaModel.GetRange(energyIni, energyFin);
+   EXPECT_TRUE(std::abs(range - rangeLISE) / rangeLISE < 0.05);
 }

--- a/AtTools/AtELossModel.cxx
+++ b/AtTools/AtELossModel.cxx
@@ -16,4 +16,20 @@ void AtELossModel::SetDensity(double density)
    fdEdxScale = fDensity / fDensityIni;
 }
 
+std::vector<std::pair<double, double>> AtELossModel::GetBraggCurve(double energy, double rangeStepSize) const
+{
+   std::vector<std::pair<double, double>> braggCurve;
+
+   double remainingEnergy{energy};
+   double range{};
+   while (remainingEnergy > 0) {
+      remainingEnergy = GetEnergy(remainingEnergy, range);
+      double dEdx = GetdEdx(remainingEnergy);
+      braggCurve.push_back(std::make_pair(dEdx, range));
+      range += rangeStepSize;
+   }
+
+   return braggCurve;
+}
+
 } // namespace AtTools

--- a/AtTools/AtELossModel.h
+++ b/AtTools/AtELossModel.h
@@ -1,6 +1,9 @@
 #ifndef ATELOSSMODEL_H
 #define ATELOSSMODEL_H
 
+#include <utility>
+#include <vector>
+
 namespace AtTools {
 
 /**
@@ -53,6 +56,14 @@ public:
     * reach energyIni after distance.
     */
    virtual double GetEnergy(double energyIni, double distance) const = 0;
+
+   /**
+    * Get the Bragg curve for a given energy as a vector of (dE/dx, distance) pairs.
+    * @param[in] energy The kinetic energy of the particle for which the curve is being computed for.
+    * @param[in] rangeStepSize The step size for the distances the Bragg curve will be computed for in mm. Default value
+    * is 0.1mm.
+    */
+   virtual std::vector<std::pair<double, double>> GetBraggCurve(double energy, double rangeStepSize = 0.1) const;
 
 protected:
    void SetIniDensity(double density)

--- a/AtTools/AtToolsLinkDef.h
+++ b/AtTools/AtToolsLinkDef.h
@@ -19,6 +19,7 @@
 #pragma link C++ class AtTools::AtTrackTransformer - !;
 #pragma link C++ class AtTools::AtELossModel - !;
 #pragma link C++ class AtTools::AtELossTable - !;
+#pragma link C++ class AtTools::AtELossCATIMA - !;
 
 #pragma link C++ class AtSpaceChargeModel - !;
 #pragma link C++ class AtLineChargeModel - !;

--- a/AtTools/CMakeLists.txt
+++ b/AtTools/CMakeLists.txt
@@ -59,6 +59,15 @@ if(HiRAEVT_FOUND)
     )
 endif()
 
+if(CATIMA_FOUND)
+  set(SRCS ${SRCS}
+    AtELossCATIMA.cxx
+    )
+  set(DEPENDENCIES ${DEPENDENCIES}
+    CATIMA::catima
+    )
+endif()
+
 Set(INCLUDE_DIR
   ${CMAKE_SOURCE_DIR}/AtTools/AtHitSampling
   ${CMAKE_SOURCE_DIR}/AtTools/ElectronicResponse
@@ -68,6 +77,11 @@ Set(INCLUDE_DIR
 set(TEST_SRCS
   DataCleaning/AtkNNTest.cxx
 )
+if(CATIMA_FOUND)
+  set(TEST_SRCS ${TEST_SRCS}
+    AtELossCATIMATest.cxx
+    )
+endif()
 
 attpcroot_generate_tests(${LIBRARY_NAME}Tests
   SRCS ${TEST_SRCS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 find_package2(PUBLIC CUDA)
 find_package2(PUBLIC HiRAEVT CONFIG)
 find_package2(PUBLIC GENFIT2)
+find_package2(PUBLIC CATIMA)
 
 find_package2(PUBLIC Eigen3 3.3 NO_MODULE)
 
@@ -223,6 +224,7 @@ install(FILES
   cmake/modules/FindPythia6.cmake
   cmake/modules/FindPythia8.cmake
   cmake/modules/FindROOT.cmake
+  cmake/modules/FindCATIMA.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules)
 
 # Install our utility scripts for others if they want

--- a/cmake/modules/FindCATIMA.cmake
+++ b/cmake/modules/FindCATIMA.cmake
@@ -1,0 +1,51 @@
+# - Find CATima installation
+# This module tries to find CATima in your system
+
+
+
+if(NOT DEFINED ENV{CATIMA} AND NOT DEFINED CATIMA)
+  message(STATUS "Looking for CATima but did not set enviroment or cmake variable CATIMA")
+endif()
+
+if(DEFINED ENV{CATIMA})
+  message(STATUS "Using enviroment variable CATIMA to search")
+  Set(CATIMA $ENV{CATIMA})
+endif()
+
+set(CATIMA_LIBRARY_SEARCHPATH
+  ${CATIMA}/lib
+)
+
+set(CATIMA_FOUND FALSE)
+
+find_library(CATIMA_LIBRARY NAMES libcatima.so
+  PATHS ${CATIMA_LIBRARY_SEARCHPATH}
+  NO_DEFAULT_PATH
+)
+
+if(CATIMA_LIBRARY)
+
+  message(STATUS "Looking for CATima... - found ${CATIMA}/lib")
+
+  get_filename_component(CATIMA_LIBRARY_DIR ${CATIMA_LIBRARY} DIRECTORY)
+  get_filename_component(CATIMA_INCLUDE_DIR ${CATIMA_LIBRARY}/../../include ABSOLUTE)
+
+  message(STATUS "CATIMA_INCLUDE_DIR = ${CATIMA_INCLUDE_DIR}")
+
+
+  mark_as_advanced(CATIMA_LIBRARY_DIR CATIMA_INCLUDE_DIR)
+
+  set(CATIMA_FOUND TRUE)
+
+  add_library(CATIMA::catima UNKNOWN IMPORTED GLOBAL)
+  set_target_properties(CATIMA::catima PROPERTIES
+    IMPORTED_LOCATION ${CATIMA_LIBRARY}
+    INTERFACE_INCLUDE_DIRECTORIES ${CATIMA_INCLUDE_DIR})
+
+else(CATIMA_LIBRARY)
+
+  if(CATIMA_FIND_REQUIRED)
+    message(FATAL_ERROR "Looking for CATima... - Not found!")
+  endif(CATIMA_FIND_REQUIRED)
+
+endif(CATIMA_LIBRARY)


### PR DESCRIPTION
Implemented CATIMA as an AtELossModel in AtTools. I copy here some notes that I added to a previous pull request that may still be relevant here.

Notes:
1. In order to get this to work, I needed to compile CATima using the DGSL integration option (cmake -DCMAKE_INSTALL_PREFIX=~/fair_install/catimaInstall -DGSL_INTEGRATION=ON ..).
2. I also needed to comment 2 lines in the file "src/storage.cpp" file from CATima (in deleter function InterpolatorGSL::~InterpolatorGSL(), just comment both lines). Maybe it was just me, but it was giving me a segmentation fault.
3. Once you have installed CATima, export the environment variable CATIMA and set it to the path where you have installed CATima (it should have 3 folders, namely: include, lib and share). In my case: export CATIMA=~/fair_install/catimaInstall
4. Now simply compile ATTPCROOTv2. It should find CATima and therefore compile the AtELossCATIMA class.