### PR TITLE
Implemented a way to invert the drift velocity direction inside the ATTPC. Also fixed the padplane-projected hits issue by adding a charge threshold...

### DIFF
--- a/AtDigitization/AtClusterize.cxx
+++ b/AtDigitization/AtClusterize.cxx
@@ -29,12 +29,15 @@ void AtClusterize::GetParameters(const AtDigiPar *fPar)
 
    fDetPadPlane = fPar->GetZPadPlane(); //[mm]
 
+   fIsTPCInverted = fPar->GetIsTPCInverted(); //[0/1]
+
    LOG(info) << "  Ionization energy of gas: " << fEIonize << " MeV";
    LOG(info) << "  Fano factor of gas: " << fFano;
    LOG(info) << "  Drift velocity: " << fVelDrift;
    LOG(info) << "  Longitudal coefficient of diffusion: " << fCoefL;
    LOG(info) << "  Transverse coefficient of diffusion: " << fCoefT;
    LOG(info) << "  Position of the pad plane (Z): " << fDetPadPlane;
+   LOG(info) << "  Is TPC inverted? " << fIsTPCInverted << " (0 = false; 1 = true)";
 }
 
 void AtClusterize::FillTClonesArray(TClonesArray &array, std::vector<SimPointPtr> &vec)
@@ -122,6 +125,9 @@ uint64_t AtClusterize::getNumberOfElectronsGenerated(const AtMCPoint &mcPoint)
 AtClusterize::XYZPoint AtClusterize::getCurrentPointLocation(const AtMCPoint &mcPoint)
 {
    auto zInCm = fDetPadPlane / 10. - mcPoint.GetZ();
+   if (fIsTPCInverted)
+      zInCm = mcPoint.GetZ();
+
    auto driftTime = TMath::Abs(zInCm) / fVelDrift; // us
 
    return {mcPoint.GetX() * 10., mcPoint.GetY() * 10., driftTime};

--- a/AtDigitization/AtClusterize.h
+++ b/AtDigitization/AtClusterize.h
@@ -33,6 +33,7 @@ protected:
    double fCoefT{};       //!< Transversal diffusion coefficient. [cm^2/us]
    double fCoefL{};       //!< Longitudinal diffusion coefficient. [cm^2/us]
    double fDetPadPlane{}; //!< Position of the pad plane with respect to the entrance [mm]
+   int fIsTPCInverted{};  //!< Whether or not the TPC is inverted with respect the usual convention [0/1]
 
    static thread_local XYZPoint fPrevPoint; //!< The previous point we recorded charge.
    static thread_local int fTrackID;        //!< The current track ID

--- a/AtParameter/AtDigiPar.cxx
+++ b/AtParameter/AtDigiPar.cxx
@@ -54,6 +54,10 @@ Bool_t AtDigiPar::getParams(FairParamList *paramList) // TODO Change all these p
          LOG(fatal) << "Cannot find ZPadPlane parameter!";
          return kFALSE;
       }
+      if (!(paramList->fill("IsTPCInverted", &fIsTPCInverted))) {
+         LOG(warning) << "Cannot find IsTPCInverted parameter! Setting it to 0 (false) by default.";
+         fIsTPCInverted = 0;
+      }
 
       if (!(paramList->fill("EIonize", &fEIonize))) {
          LOG(fatal) << "Cannot find EIonize parameter!";
@@ -117,6 +121,7 @@ void AtDigiPar::putParams(FairParamList *paramList)
 
    paramList->add("TBEntrance", fTBEntrance);
    paramList->add("ZPadPlane", fZPadPlane);
+   paramList->add("IsTPCInverted", fIsTPCInverted);
 
    paramList->add("EIonize", fEIonize);
    paramList->add("Fano", fFano);

--- a/AtParameter/AtDigiPar.h
+++ b/AtParameter/AtDigiPar.h
@@ -21,6 +21,7 @@ private:
    // Detector geometry
    Int_t fTBEntrance{};
    Double_t fZPadPlane{};
+   Int_t fIsTPCInverted{}; //< Whether or not the TPC drift is inverted [0/1]
 
    // Gas properties
    Double_t fEIonize{};       //< effective ionization energy [eV]
@@ -48,6 +49,7 @@ public:
 
    Int_t GetTBEntrance() const { return fTBEntrance; }
    Double_t GetZPadPlane() const { return fZPadPlane; }
+   Int_t GetIsTPCInverted() const { return fIsTPCInverted; }
 
    Double_t GetEIonize() const { return fEIonize; }
    Double_t GetFano() const { return fFano; }
@@ -67,7 +69,7 @@ public:
    virtual Bool_t getParams(FairParamList *paramList) override;
    // Main methods
 
-   ClassDefOverride(AtDigiPar, 4);
+   ClassDefOverride(AtDigiPar, 5);
 };
 
 #endif

--- a/AtReconstruction/AtPulseAnalyzer/AtPSA.cxx
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSA.cxx
@@ -50,6 +50,7 @@ void AtPSA::Init()
    fEField = fPar->GetEField();
    fZk = fPar->GetZPadPlane();
    fEntTB = (Int_t)fPar->GetTBEntrance();
+   fIsTPCInverted = fPar->GetIsTPCInverted(); //[0/1]
 
    auto timeToPadPlane = fZk / (fDriftVelocity * 1e-2); //[ns]
    fTB0 = fEntTB - timeToPadPlane / fTBTime;
@@ -62,6 +63,7 @@ void AtPSA::Init()
    std::cout << " ==== Entrance TB : " << fEntTB << std::endl;
    std::cout << " ==== Pad plane TB : " << fTB0 << std::endl;
    std::cout << " ==== NumTbs : " << fNumTbs << std::endl;
+   std::cout << " ==== Is TPC inverted? : " << fIsTPCInverted << " (0 = false; 1 = true)" << std::endl;
 }
 
 void AtPSA::SetSimulatedEvent(TClonesArray *MCSimPointArray)
@@ -84,11 +86,15 @@ void AtPSA::SetThresholdLow(Int_t thresholdlow)
 
 Double_t AtPSA::CalculateZ(Double_t peakIdx)
 {
+   if (fIsTPCInverted)
+      return fZk - (fNumTbs - peakIdx) * fTBTime * fDriftVelocity / 100.;
    return (fNumTbs - peakIdx) * fTBTime * fDriftVelocity / 100.;
 }
 
 Double_t AtPSA::CalculateZGeo(Double_t peakIdx)
 {
+   if (fIsTPCInverted)
+      return (fEntTB - peakIdx) * fTBTime * fDriftVelocity / 100.;
    return fZk - (fEntTB - peakIdx) * fTBTime * fDriftVelocity / 100.;
 }
 

--- a/AtReconstruction/AtPulseAnalyzer/AtPSA.h
+++ b/AtReconstruction/AtPulseAnalyzer/AtPSA.h
@@ -46,6 +46,7 @@ protected:
    Int_t fEntTB{};            //< Timebucket of the entrance window
    Double_t fDriftVelocity{}; //< drift velocity of electron in cm/us
    Double_t fZk{};            //< Relative position of micromegas-cathode
+   Int_t fIsTPCInverted{};    //< Whether or not the TPC is inverted with respect the usual convention [0/1]
 
    using HitVector = std::vector<std::unique_ptr<AtHit>>;
 
@@ -81,7 +82,7 @@ protected:
 
    virtual double getZhitVariance(double zLoc, double zLocVar) const;
    virtual std::pair<double, double> getXYhitVariance() const;
-   ClassDef(AtPSA, 5)
+   ClassDef(AtPSA, 6)
 };
 
 #endif

--- a/macro/tests/BraggCurveTesting/Be13_p_sim.C
+++ b/macro/tests/BraggCurveTesting/Be13_p_sim.C
@@ -1,4 +1,4 @@
-void Be13_p_sim(Int_t nEvents = 10000, Int_t subnum = 0, Double_t angle_cm = 180)
+void Be13_p_sim(Int_t nEvents = 10000, Int_t subnum = 0, Double_t angle_cm = 50)
 {
    // Int_t subnum = 0,
    srand((unsigned)time(NULL));

--- a/macro/tests/BraggCurveTesting/BraggCurveTesting.par
+++ b/macro/tests/BraggCurveTesting/BraggCurveTesting.par
@@ -10,6 +10,7 @@ EField:Double_t               7000   # V/m
 BField:Double_t                0.0   # Tesla
 TBEntrance:Int_t               400   # Beam position at detector entrance in TB 382
 ZPadPlane:Double_t          1000.0   # Position of the micromegas pad plane
+IsTPCInverted:Int_t              1   # Is the drift direction inverted? [0=false;1=true]
 EIonize:Double_t                23   # Ionization energy of gas in eV
 Fano:Double_t                 0.24   # Fano factor of the gas
 CoefL:Double_t              0.0001   # Longitudal coefficient of diffusion [cm^2/us]

--- a/macro/tests/BraggCurveTesting/digi_Be13_p.C
+++ b/macro/tests/BraggCurveTesting/digi_Be13_p.C
@@ -1,6 +1,6 @@
 bool reduceFunc(AtRawEvent *evt);
 
-void digi_Be13_p(int nEvent = 10000, int subnum = 0, int angle_cm = 180)
+void digi_Be13_p(int nEvent = 10000, int subnum = 0, int angle_cm = 50)
 {
    const char *filename = "13Be_p";
    double minangle, maxangle;
@@ -49,7 +49,7 @@ void digi_Be13_p(int nEvent = 10000, int subnum = 0, int angle_cm = 180)
    pulse->SetPersistence(kTRUE);
 
    auto psa = std::make_unique<AtPSAMax>();
-   // psa->SetThreshold(5);
+   psa->SetThreshold(5);
 
    // Create PSA task
    AtPSAtask *psaTask = new AtPSAtask(std::move(psa));

--- a/macro/tests/BraggCurveTesting/eventDisplay.C
+++ b/macro/tests/BraggCurveTesting/eventDisplay.C
@@ -1,8 +1,7 @@
 void eventDisplay()
 {
   //-----User Settings:-----------------------------------------------
-  //TString  InputFile     ="attpcsim_13Be_p_0.0_180.0_550Torr_Xiaobin.root";
-  TString  InputFile     ="attpcsim_13Be_p_0.0_180.0_550Torr.root";
+  TString  InputFile     ="attpcsim_13Be_p_0.0_50.0_550Torr.root";
   TString  ParFile       ="attpcpar_13Be_p.root";
   TString  OutFile	     ="attpctest.root";
 
@@ -22,8 +21,8 @@ void eventDisplay()
   FairEventManager *fMan= new FairEventManager();
 
   //----------------------Traks and points -------------------------------------
-  //FairMCTracks    *Track     = new FairMCTracks("Monte-Carlo Tracks");
-  FairMCPointDraw *AtTpcPoints = new FairMCPointDraw("AtTpcPoint", kBlue, kFullSquare);
+  //FairMCTracksDraw *Track       = new FairMCTracksDraw("MCTrack");
+  FairMCPointDraw  *AtTpcPoints = new FairMCPointDraw("AtTpcPoint", kBlue, kFullSquare);
 
   //fMan->AddTask(Track);
   fMan->AddTask(AtTpcPoints);

--- a/macro/tests/BraggCurveTesting/run_eve.C
+++ b/macro/tests/BraggCurveTesting/run_eve.C
@@ -1,7 +1,7 @@
 
 void run_eve()
 {
-   TString InputDataPath = "./output_digi_rcnp_13Be_p_0.0_180.0_hole_550Torr.root";
+   TString InputDataPath = "./output_digi_rcnp_13Be_p_0.0_50.0_hole_550Torr.root";
    TString OutputDataPath = "./output.reco_display.root";
    std::cout << "Opening: " << InputDataPath << std::endl;
 


### PR DESCRIPTION
Small change. Added a geometry parameter on AtDigiPar which determines if the drift direction is inverted or not:

- 0=False => The drift direction is not inverted. In the context of ATTPC, the padplane is at the exit of the detector.
- 1=True  => The drift direction is inverted. In the context of ATTPC, the padplane is at the entrance of the detector.

If this parameter is not set in the .par file, the default value is set to 0, so that all previous .par files should still work as expected.

I also added a quick fix for a test simulation from #257 which removes the padplane-projected hits. I thought those had something to do with the inversion of the drift velocity, but they ended up just being produced by the AtPSA when no peak can be found for the pad. Adding a charge threshold of 5 removes those.